### PR TITLE
feat: update action stage and condition commands to use new naming co…

### DIFF
--- a/apps/kobold-client/src/commands/chat/action-stage/action-stage-add-basic-damage-subcommand.ts
+++ b/apps/kobold-client/src/commands/chat/action-stage/action-stage-add-basic-damage-subcommand.ts
@@ -54,8 +54,8 @@ export class ActionStageAddBasicDamageSubCommand extends BaseCommandClass(
 		const healInsteadOfDamage =
 			intr.options.getBoolean(commandOptions[commandOptionsEnum.healInsteadOfDamage].name) ??
 			false;
-		const basicDamageDiceRoll = intr.options.getString(
-			commandOptions[commandOptionsEnum.basicDamageDiceRoll].name,
+		const diceRoll = intr.options.getString(
+			commandOptions[commandOptionsEnum.diceRoll].name,
 			true
 		);
 		let allowRollModifiers = intr.options.getBoolean(
@@ -92,7 +92,7 @@ export class ActionStageAddBasicDamageSubCommand extends BaseCommandClass(
 			name: rollName,
 			type: rollType,
 			healInsteadOfDamage,
-			roll: basicDamageDiceRoll,
+			roll: diceRoll,
 			damageType: damageType,
 			allowRollModifiers,
 		});

--- a/apps/kobold-client/src/commands/chat/condition/condition-apply-modifier-subcommand.ts
+++ b/apps/kobold-client/src/commands/chat/condition/condition-apply-modifier-subcommand.ts
@@ -35,9 +35,9 @@ export class ConditionApplyModifierSubCommand extends BaseCommandClass(
 			const { autocompleteUtils } = new KoboldUtils(kobold);
 			return await autocompleteUtils.getAllTargetOptions(intr, match);
 		}
-		if (option.name === commandOptions[commandOptionsEnum.name].name) {
+		if (option.name === commandOptions[commandOptionsEnum.modifierName].name) {
 			const match =
-				intr.options.getString(commandOptions[commandOptionsEnum.name].name) ?? '';
+				intr.options.getString(commandOptions[commandOptionsEnum.modifierName].name) ?? '';
 
 			//get the active character
 			const allCharacters = await kobold.character.readMany({ userId: intr.user.id });
@@ -81,7 +81,7 @@ export class ConditionApplyModifierSubCommand extends BaseCommandClass(
 		);
 
 		const targetModifierName = intr.options.getString(
-			commandOptions[commandOptionsEnum.name].name,
+			commandOptions[commandOptionsEnum.modifierName].name,
 			true
 		);
 		const [sourceCharacterName, conditionName] = targetModifierName

--- a/apps/kobold-client/src/commands/chat/condition/condition-remove-subcommand.ts
+++ b/apps/kobold-client/src/commands/chat/condition/condition-remove-subcommand.ts
@@ -38,10 +38,10 @@ export class ConditionRemoveSubCommand extends BaseCommandClass(
 			const { autocompleteUtils } = new KoboldUtils(kobold);
 			return await autocompleteUtils.getAllTargetOptions(intr, match);
 		}
-		if (option.name === commandOptions[commandOptionsEnum.name].name) {
+		if (option.name === commandOptions[commandOptionsEnum.conditionName].name) {
 			//we don't need to autocomplete if we're just dealing with whitespace
 			const match =
-				intr.options.getString(commandOptions[commandOptionsEnum.name].name) ?? '';
+				intr.options.getString(commandOptions[commandOptionsEnum.conditionName].name) ?? '';
 			const targetCharacterName =
 				intr.options.getString(commandOptions[commandOptionsEnum.targetCharacter].name) ??
 				'';
@@ -60,7 +60,7 @@ export class ConditionRemoveSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<void> {
 		const conditionChoice = intr.options.getString(
-			commandOptions[commandOptionsEnum.name].name,
+			commandOptions[commandOptionsEnum.conditionName].name,
 			true
 		);
 		const targetCharacterName = intr.options.getString(

--- a/apps/kobold-client/src/commands/chat/condition/condition-set-subcommand.ts
+++ b/apps/kobold-client/src/commands/chat/condition/condition-set-subcommand.ts
@@ -39,10 +39,10 @@ export class ConditionSetSubCommand extends BaseCommandClass(
 			const { autocompleteUtils } = new KoboldUtils(kobold);
 			return await autocompleteUtils.getAllTargetOptions(intr, match);
 		}
-		if (option.name === commandOptions[commandOptionsEnum.name].name) {
+		if (option.name === commandOptions[commandOptionsEnum.conditionName].name) {
 			//we don't need to autocomplete if we're just dealing with whitespace
 			const match =
-				intr.options.getString(commandOptions[commandOptionsEnum.name].name) ?? '';
+				intr.options.getString(commandOptions[commandOptionsEnum.conditionName].name) ?? '';
 			const targetCharacterName =
 				intr.options.getString(commandOptions[commandOptionsEnum.targetCharacter].name) ??
 				'';
@@ -64,7 +64,7 @@ export class ConditionSetSubCommand extends BaseCommandClass(
 			.getString(commandOptions[commandOptionsEnum.targetCharacter].name, true)
 			.trim();
 		const conditionName = intr.options
-			.getString(commandOptions[commandOptionsEnum.name].name, true)
+			.getString(commandOptions[commandOptionsEnum.conditionName].name, true)
 			.trim();
 		let fieldToChange = intr.options
 			.getString(commandOptions[commandOptionsEnum.setOption].name, true)

--- a/apps/kobold-client/src/commands/chat/condition/condition-severity-subcommand.ts
+++ b/apps/kobold-client/src/commands/chat/condition/condition-severity-subcommand.ts
@@ -33,10 +33,10 @@ export class ConditionSeveritySubCommand extends BaseCommandClass(
 			const { autocompleteUtils } = new KoboldUtils(kobold);
 			return await autocompleteUtils.getAllTargetOptions(intr, match);
 		}
-		if (option.name === commandOptions[commandOptionsEnum.name].name) {
+		if (option.name === commandOptions[commandOptionsEnum.conditionName].name) {
 			//we don't need to autocomplete if we're just dealing with whitespace
 			const match =
-				intr.options.getString(commandOptions[commandOptionsEnum.name].name) ?? '';
+				intr.options.getString(commandOptions[commandOptionsEnum.conditionName].name) ?? '';
 			const targetCharacterName =
 				intr.options.getString(commandOptions[commandOptionsEnum.targetCharacter].name) ??
 				'';
@@ -55,7 +55,7 @@ export class ConditionSeveritySubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<void> {
 		const conditionName = intr.options
-			.getString(commandOptions[commandOptionsEnum.name].name, true)
+			.getString(commandOptions[commandOptionsEnum.conditionName].name, true)
 			.trim();
 		const newSeverity = intr.options
 			.getString(commandOptions[commandOptionsEnum.severity].name, true)

--- a/apps/kobold-client/src/commands/chat/modifier/index.ts
+++ b/apps/kobold-client/src/commands/chat/modifier/index.ts
@@ -1,6 +1,6 @@
 import { CommandExport } from '../../command.js';
 import { ModifierCommand } from './modifier-command.js';
-import { ModifierCreateModifierSubCommand } from './modifier-create-modifier-subcommand.js';
+import { ModifierCreateSubCommand } from './modifier-create-subcommand.js';
 import { ModifierDetailSubCommand } from './modifier-detail-subcommand.js';
 import { ModifierExportSubCommand } from './modifier-export-subcommand.js';
 import { ModifierImportSubCommand } from './modifier-import-subcommand.js';
@@ -13,7 +13,7 @@ import { ModifierSetSubCommand } from './modifier-set-subcommand.js';
 export const ModifierCommandExport: CommandExport = {
 	command: ModifierCommand,
 	subCommands: [
-		ModifierCreateModifierSubCommand,
+		ModifierCreateSubCommand,
 		ModifierDetailSubCommand,
 		ModifierExportSubCommand,
 		ModifierImportSubCommand,

--- a/apps/kobold-client/src/commands/chat/modifier/modifier-create-subcommand.spec.ts
+++ b/apps/kobold-client/src/commands/chat/modifier/modifier-create-subcommand.spec.ts
@@ -1,10 +1,10 @@
 /**
- * Unit tests for ModifierCreateModifierSubCommand
+ * Unit tests for ModifierCreateSubCommand
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { SheetAdjustmentTypeEnum } from '@kobold/db';
 import { ModifierCommand } from './modifier-command.js';
-import { ModifierCreateModifierSubCommand } from './modifier-create-modifier-subcommand.js';
+import { ModifierCreateSubCommand } from './modifier-create-subcommand.js';
 import {
 	createTestHarness,
 	createMockCharacter,
@@ -14,7 +14,8 @@ import {
 	TEST_GUILD_ID,
 	CommandTestHarness,
 	getMockKobold,
-	resetMockKobold,} from '../../../test-utils/index.js';
+	resetMockKobold,
+} from '../../../test-utils/index.js';
 import { KoboldUtils } from '../../../utils/kobold-service-utils/kobold-utils.js';
 import { FinderHelpers } from '../../../utils/kobold-helpers/finder-helpers.js';
 import { InputParseUtils } from '../../../utils/input-parse-utils.js';
@@ -47,16 +48,14 @@ vi.mock('../../../utils/input-parse-utils.js', () => ({
 	},
 }));
 
-describe('ModifierCreateModifierSubCommand', () => {
+describe('ModifierCreateSubCommand', () => {
 	const kobold = getMockKobold();
 
 	let harness: CommandTestHarness;
 
 	beforeEach(() => {
 		resetMockKobold(kobold);
-		harness = createTestHarness([
-			new ModifierCommand([new ModifierCreateModifierSubCommand()]),
-		]);
+		harness = createTestHarness([new ModifierCommand([new ModifierCreateSubCommand()])]);
 	});
 
 	describe('successful modifier creation', () => {
@@ -72,7 +71,7 @@ describe('ModifierCreateModifierSubCommand', () => {
 			// Act
 			const result = await harness.executeCommand({
 				commandName: 'modifier',
-				subcommand: 'create-modifier',
+				subcommand: 'create',
 				options: {
 					name: 'Inspire Courage',
 					type: SheetAdjustmentTypeEnum.status,
@@ -100,7 +99,7 @@ describe('ModifierCreateModifierSubCommand', () => {
 			// Act
 			const result = await harness.executeCommand({
 				commandName: 'modifier',
-				subcommand: 'create-modifier',
+				subcommand: 'create',
 				options: {
 					name: 'Strength Boost',
 					type: SheetAdjustmentTypeEnum.status,
@@ -127,7 +126,7 @@ describe('ModifierCreateModifierSubCommand', () => {
 			// Act
 			const result = await harness.executeCommand({
 				commandName: 'modifier',
-				subcommand: 'create-modifier',
+				subcommand: 'create',
 				options: {
 					name: 'Frightened',
 					type: SheetAdjustmentTypeEnum.status,
@@ -155,7 +154,7 @@ describe('ModifierCreateModifierSubCommand', () => {
 			// Act
 			const result = await harness.executeCommand({
 				commandName: 'modifier',
-				subcommand: 'create-modifier',
+				subcommand: 'create',
 				options: {
 					name: 'Bard Song',
 					type: SheetAdjustmentTypeEnum.status,
@@ -198,7 +197,7 @@ describe('ModifierCreateModifierSubCommand', () => {
 			// Act
 			const result = await harness.executeCommand({
 				commandName: 'modifier',
-				subcommand: 'create-modifier',
+				subcommand: 'create',
 				options: {
 					name: 'Existing Modifier',
 					type: SheetAdjustmentTypeEnum.status,
@@ -226,7 +225,7 @@ describe('ModifierCreateModifierSubCommand', () => {
 			// Act
 			const result = await harness.executeCommand({
 				commandName: 'modifier',
-				subcommand: 'create-modifier',
+				subcommand: 'create',
 				options: {
 					name: 'Invalid Modifier',
 					type: SheetAdjustmentTypeEnum.status,
@@ -253,7 +252,7 @@ describe('ModifierCreateModifierSubCommand', () => {
 			// Act
 			const result = await harness.executeCommand({
 				commandName: 'modifier',
-				subcommand: 'create-modifier',
+				subcommand: 'create',
 				options: {
 					name: 'Invalid Modifier',
 					type: SheetAdjustmentTypeEnum.status,
@@ -280,7 +279,7 @@ describe('ModifierCreateModifierSubCommand', () => {
 			// Act
 			const result = await harness.executeCommand({
 				commandName: 'modifier',
-				subcommand: 'create-modifier',
+				subcommand: 'create',
 				options: {
 					name: 'Empty Modifier',
 					type: SheetAdjustmentTypeEnum.status,

--- a/apps/kobold-client/src/commands/chat/modifier/modifier-create-subcommand.ts
+++ b/apps/kobold-client/src/commands/chat/modifier/modifier-create-subcommand.ts
@@ -20,9 +20,9 @@ import { BaseCommandClass } from '../../command.js';
 const commandOptions = ModifierDefinition.options;
 const commandOptionsEnum = ModifierDefinition.commandOptionsEnum;
 
-export class ModifierCreateModifierSubCommand extends BaseCommandClass(
+export class ModifierCreateSubCommand extends BaseCommandClass(
 	ModifierDefinition,
-	ModifierDefinition.subCommandEnum.createModifier
+	ModifierDefinition.subCommandEnum.create
 ) {
 	public async execute(
 		intr: ChatInputCommandInteraction,
@@ -104,7 +104,9 @@ export class ModifierCreateModifierSubCommand extends BaseCommandClass(
 					new Creature(activeCharacter.sheetRecord, undefined, intr)
 				)
 			) {
-				throw new KoboldError(ModifierDefinition.strings.createModifier.doesntEvaluateError);
+				throw new KoboldError(
+					ModifierDefinition.strings.createModifier.doesntEvaluateError
+				);
 			}
 		}
 

--- a/packages/documentation/src/commands/action-stage/action-stage.command-definition.ts
+++ b/packages/documentation/src/commands/action-stage/action-stage.command-definition.ts
@@ -97,8 +97,8 @@ export const actionStageCommandDefinition = {
 					actionStageCommandOptions[ActionStageCommandOptionEnum.rollName],
 					2
 				),
-				[ActionStageCommandOptionEnum.basicDamageDiceRoll]: withOrder(
-					actionStageCommandOptions[ActionStageCommandOptionEnum.basicDamageDiceRoll],
+				[ActionStageCommandOptionEnum.diceRoll]: withOrder(
+					actionStageCommandOptions[ActionStageCommandOptionEnum.diceRoll],
 					3
 				),
 				[ActionStageCommandOptionEnum.damageType]: withOrder(

--- a/packages/documentation/src/commands/action-stage/action-stage.command-options.ts
+++ b/packages/documentation/src/commands/action-stage/action-stage.command-options.ts
@@ -15,7 +15,6 @@ export enum ActionStageCommandOptionEnum {
 	rollName = 'roll-name',
 	diceRoll = 'dice-roll',
 	damageType = 'damage-type',
-	basicDamageDiceRoll = 'basic-damage-dice-roll',
 	successDiceRoll = 'success-dice-roll',
 	criticalSuccessDiceRoll = 'critical-success-dice-roll',
 	criticalFailureDiceRoll = 'critical-failure-dice-roll',
@@ -138,19 +137,13 @@ export const actionStageCommandOptions = {
 	},
 	[ActionStageCommandOptionEnum.diceRoll]: {
 		name: 'dice-roll',
-		description: 'The dice roll for the action.',
+		description: 'The dice rolled for the stage.',
 		required: true,
 		type: ApplicationCommandOptionType.String,
 	},
 	[ActionStageCommandOptionEnum.damageType]: {
 		name: 'damage-type',
 		description: 'The type of damage.',
-		required: true,
-		type: ApplicationCommandOptionType.String,
-	},
-	[ActionStageCommandOptionEnum.basicDamageDiceRoll]: {
-		name: 'basic-damage-dice-roll',
-		description: 'The basic damage dice roll.',
 		required: true,
 		type: ApplicationCommandOptionType.String,
 	},

--- a/packages/documentation/src/commands/action-stage/action-stage.documentation.ts
+++ b/packages/documentation/src/commands/action-stage/action-stage.documentation.ts
@@ -66,7 +66,7 @@ export const actionStageCommandDocumentation: CommandDocumentation<
 						[ActionStageCommandOptionEnum.actionTarget]: 'Elemental Blast (1a)',
 						[ActionStageCommandOptionEnum.rollName]: 'Elemental Blast',
 						[ActionStageCommandOptionEnum.damageType]: 'Fire',
-						[ActionStageCommandOptionEnum.basicDamageDiceRoll]: '1d6 + 3',
+						[ActionStageCommandOptionEnum.diceRoll]: '1d6 + 3',
 					},
 				},
 			],

--- a/packages/documentation/src/commands/condition/condition.command-definition.ts
+++ b/packages/documentation/src/commands/condition/condition.command-definition.ts
@@ -77,11 +77,8 @@ export const conditionCommandDefinition = {
 					conditionCommandOptions[ConditionCommandOptionEnum.targetCharacter],
 					1
 				),
-				[ConditionCommandOptionEnum.name]: withOrder(
-					{
-						...conditionCommandOptions[ConditionCommandOptionEnum.name],
-						required: false,
-					},
+				[ConditionCommandOptionEnum.modifierName]: withOrder(
+					conditionCommandOptions[ConditionCommandOptionEnum.modifierName],
 					2
 				),
 			},
@@ -106,8 +103,8 @@ export const conditionCommandDefinition = {
 					conditionCommandOptions[ConditionCommandOptionEnum.targetCharacter],
 					1
 				),
-				[ConditionCommandOptionEnum.name]: withOrder(
-					conditionCommandOptions[ConditionCommandOptionEnum.name],
+				[ConditionCommandOptionEnum.conditionName]: withOrder(
+					conditionCommandOptions[ConditionCommandOptionEnum.conditionName],
 					2
 				),
 				[ConditionCommandOptionEnum.setOption]: withOrder(
@@ -129,8 +126,8 @@ export const conditionCommandDefinition = {
 					conditionCommandOptions[ConditionCommandOptionEnum.targetCharacter],
 					1
 				),
-				[ConditionCommandOptionEnum.name]: withOrder(
-					conditionCommandOptions[ConditionCommandOptionEnum.name],
+				[ConditionCommandOptionEnum.conditionName]: withOrder(
+					conditionCommandOptions[ConditionCommandOptionEnum.conditionName],
 					2
 				),
 			},
@@ -144,8 +141,8 @@ export const conditionCommandDefinition = {
 					conditionCommandOptions[ConditionCommandOptionEnum.targetCharacter],
 					1
 				),
-				[ConditionCommandOptionEnum.name]: withOrder(
-					conditionCommandOptions[ConditionCommandOptionEnum.name],
+				[ConditionCommandOptionEnum.conditionName]: withOrder(
+					conditionCommandOptions[ConditionCommandOptionEnum.conditionName],
 					2
 				),
 				[ConditionCommandOptionEnum.severity]: withOrder(

--- a/packages/documentation/src/commands/condition/condition.command-options.ts
+++ b/packages/documentation/src/commands/condition/condition.command-options.ts
@@ -1,9 +1,13 @@
 import { ApplicationCommandOptionType } from 'discord-api-types/v10';
-import type { CommandOptions, SpecificCommandOptions } from '../helpers/commands.types.js';
+import type { SpecificCommandOptions } from '../helpers/commands.types.js';
 
 export enum ConditionCommandOptionEnum {
+	// Inputtable name
 	name = 'name',
-	targetCharacter = 'gameplay-target-character',
+	// Autocompletable name
+	conditionName = 'condition-name',
+	modifierName = 'modifier-name',
+	targetCharacter = 'target-character',
 	severity = 'severity',
 	sheetValues = 'sheet-values',
 	rollAdjustment = 'roll-adjustment',
@@ -18,7 +22,21 @@ export enum ConditionCommandOptionEnum {
 export const conditionCommandOptions = {
 	[ConditionCommandOptionEnum.name]: {
 		name: 'name',
-		description: 'The name of the condition or modifier.',
+		description: 'The name of the condition.',
+		autocomplete: false,
+		required: true,
+		type: ApplicationCommandOptionType.String,
+	},
+	[ConditionCommandOptionEnum.conditionName]: {
+		name: 'condition-name',
+		description: 'The name of the condition.',
+		autocomplete: true,
+		required: true,
+		type: ApplicationCommandOptionType.String,
+	},
+	[ConditionCommandOptionEnum.modifierName]: {
+		name: 'modifier-name',
+		description: 'The name of the modifier.',
 		autocomplete: true,
 		required: true,
 		type: ApplicationCommandOptionType.String,
@@ -27,6 +45,7 @@ export const conditionCommandOptions = {
 		name: ConditionCommandOptionEnum.targetCharacter,
 		description: 'What character to update. Defaults to your active character.',
 		required: true,
+		autocomplete: true,
 		type: ApplicationCommandOptionType.String,
 	},
 	[ConditionCommandOptionEnum.severity]: {

--- a/packages/documentation/src/commands/condition/condition.documentation.ts
+++ b/packages/documentation/src/commands/condition/condition.documentation.ts
@@ -1,7 +1,5 @@
-import { GameplayCommandOptionEnum } from '../gameplay/index.js';
 import type { CommandDocumentation } from '../helpers/commands.types.js';
 import { CommandResponseTypeEnum } from '../helpers/enums.js';
-import { ModifierCommandOptionEnum } from '../modifier/index.js';
 import {
 	conditionCommandDefinition,
 	ConditionSubCommandEnum,
@@ -24,13 +22,13 @@ export const conditionCommandDocumentation: CommandDocumentation<
 					type: CommandResponseTypeEnum.success,
 					message: 'Yip! I applied the condition Blinded to Kobold Cavern Mage..',
 					options: {
-						[GameplayCommandOptionEnum.gameplayTargetCharacter]: 'Kobold Cavern Mage',
-						[ModifierCommandOptionEnum.name]: 'Blinded',
-						[ModifierCommandOptionEnum.sheetValues]: 'perception - 4',
-						[ModifierCommandOptionEnum.type]: '',
-						[ModifierCommandOptionEnum.description]:
+						[ConditionCommandOptionEnum.targetCharacter]: 'Kobold Cavern Mage',
+						[ConditionCommandOptionEnum.name]: 'Blinded',
+						[ConditionCommandOptionEnum.sheetValues]: 'perception - 4',
+						[ConditionCommandOptionEnum.type]: '',
+						[ConditionCommandOptionEnum.description]:
 							"All normal terrain is difficult terrain to you. You can't detect anything using vision. You automatically critically fail sight Perception checks, you take a –4 status penalty to Perception checks. You are immune to visual effects.",
-						[ModifierCommandOptionEnum.initiativeNote]:
+						[ConditionCommandOptionEnum.initiativeNote]:
 							'Immune to visual. All terrain difficult.',
 					},
 				},
@@ -39,13 +37,13 @@ export const conditionCommandDocumentation: CommandDocumentation<
 					type: CommandResponseTypeEnum.success,
 					message: 'Yip! I applied the condition Frightened to Kobold Cavern Mage.',
 					options: {
-						[GameplayCommandOptionEnum.gameplayTargetCharacter]: 'Kobold Cavern Mage',
-						[ModifierCommandOptionEnum.name]: 'Frightened',
-						[ModifierCommandOptionEnum.sheetValues]: '-[severity] to checks and DCs',
-						[ModifierCommandOptionEnum.type]: 'status',
-						[ModifierCommandOptionEnum.rollAdjustment]: '-[severity]',
-						[ModifierCommandOptionEnum.targetTags]: 'attack and not damage',
-						[ModifierCommandOptionEnum.severity]: 1,
+						[ConditionCommandOptionEnum.targetCharacter]: 'Kobold Cavern Mage',
+						[ConditionCommandOptionEnum.name]: 'Frightened',
+						[ConditionCommandOptionEnum.sheetValues]: '-[severity] to checks and DCs',
+						[ConditionCommandOptionEnum.type]: 'status',
+						[ConditionCommandOptionEnum.rollAdjustment]: '-[severity]',
+						[ConditionCommandOptionEnum.targetTags]: 'attack and not damage',
+						[ConditionCommandOptionEnum.severity]: 1,
 					},
 				},
 			],
@@ -60,8 +58,8 @@ export const conditionCommandDocumentation: CommandDocumentation<
 					type: CommandResponseTypeEnum.success,
 					message: 'Yip! I applied the condition Off Guard to Kobold Cavern Mage.',
 					options: {
-						[GameplayCommandOptionEnum.gameplayTargetCharacter]: 'Kobold Cavern Mage',
-						[ModifierCommandOptionEnum.name]: 'Lilac Sootsnout - Off Guard',
+						[ConditionCommandOptionEnum.targetCharacter]: 'Kobold Cavern Mage',
+						[ConditionCommandOptionEnum.modifierName]: 'Lilac Sootsnout - Off Guard',
 					},
 				},
 			],
@@ -75,7 +73,7 @@ export const conditionCommandDocumentation: CommandDocumentation<
 					title: 'Success',
 					type: CommandResponseTypeEnum.success,
 					options: {
-						[GameplayCommandOptionEnum.gameplayTargetCharacter]: 'Kobold Cavern Mage',
+						[ConditionCommandOptionEnum.targetCharacter]: 'Kobold Cavern Mage',
 					},
 					embeds: [
 						{
@@ -112,10 +110,10 @@ export const conditionCommandDocumentation: CommandDocumentation<
 					message:
 						"Yip! Kobold Cavern Mage had their condition Blinded's sheet-values set to perceptionBonus - 4.",
 					options: {
-						[GameplayCommandOptionEnum.gameplayTargetCharacter]: 'Kobold Cavern Mage',
-						[ConditionCommandOptionEnum.name]: 'Blinded',
-						[ModifierCommandOptionEnum.setOption]: 'sheet-values',
-						[ModifierCommandOptionEnum.setValue]: 'perceptionBonus - 4',
+						[ConditionCommandOptionEnum.targetCharacter]: 'Kobold Cavern Mage',
+						[ConditionCommandOptionEnum.conditionName]: 'Blinded',
+						[ConditionCommandOptionEnum.setOption]: 'sheet-values',
+						[ConditionCommandOptionEnum.setValue]: 'perceptionBonus - 4',
 					},
 				},
 			],
@@ -130,8 +128,8 @@ export const conditionCommandDocumentation: CommandDocumentation<
 					type: CommandResponseTypeEnum.success,
 					message: 'Yip! I removed the condition Blinded from Kobold Cavern Mage.',
 					options: {
-						[GameplayCommandOptionEnum.gameplayTargetCharacter]: 'Kobold Cavern Mage',
-						[ConditionCommandOptionEnum.name]: 'Blinded',
+						[ConditionCommandOptionEnum.targetCharacter]: 'Kobold Cavern Mage',
+						[ConditionCommandOptionEnum.conditionName]: 'Blinded',
 					},
 				},
 			],
@@ -147,9 +145,9 @@ export const conditionCommandDocumentation: CommandDocumentation<
 					message:
 						'Yip! I changed the severity of Frightened to 2 for Kobold Cavern Mage.',
 					options: {
-						[GameplayCommandOptionEnum.gameplayTargetCharacter]: 'Kobold Cavern Mage',
-						[ConditionCommandOptionEnum.name]: 'Frightened',
-						[ModifierCommandOptionEnum.severity]: 2,
+						[ConditionCommandOptionEnum.targetCharacter]: 'Kobold Cavern Mage',
+						[ConditionCommandOptionEnum.conditionName]: 'Frightened',
+						[ConditionCommandOptionEnum.severity]: 2,
 					},
 				},
 			],

--- a/packages/documentation/src/commands/game/game.command-options.ts
+++ b/packages/documentation/src/commands/game/game.command-options.ts
@@ -23,6 +23,7 @@ export const gameCommandOptions = {
 		name: GameCommandOptionEnum.gameGiveOption,
 		description: 'The type of resource to give of (eg. hp, hero points, etc).',
 		required: true,
+		autocomplete: true,
 		type: ApplicationCommandOptionType.String,
 	},
 	[GameCommandOptionEnum.gameGiveAmount]: {

--- a/packages/documentation/src/commands/init/init.command-options.ts
+++ b/packages/documentation/src/commands/init/init.command-options.ts
@@ -157,7 +157,7 @@ export const initCommandOptions = {
 	[InitCommandOptionEnum.rollExpression]: {
 		name: 'dice',
 		description: 'The dice expression to roll. Similar to Roll20 dice rolls.',
-		required: true,
+		required: false,
 		type: ApplicationCommandOptionType.String,
 	},
 	[InitCommandOptionEnum.rollModifier]: {

--- a/packages/documentation/src/commands/modifier/modifier.command-definition.ts
+++ b/packages/documentation/src/commands/modifier/modifier.command-definition.ts
@@ -13,7 +13,7 @@ export enum ModifierSubCommandEnum {
 	detail = 'detail',
 	export = 'export',
 	import = 'import',
-	createModifier = 'create-modifier',
+	create = 'create',
 	toggle = 'toggle',
 	severity = 'severity',
 	set = 'set',
@@ -70,8 +70,8 @@ export const modifierCommandDefinition = {
 				),
 			},
 		},
-		[ModifierSubCommandEnum.createModifier]: {
-			name: ModifierSubCommandEnum.createModifier,
+		[ModifierSubCommandEnum.create]: {
+			name: ModifierSubCommandEnum.create,
 			description: 'Creates a modifier for the active character.',
 			type: ApplicationCommandOptionType.Subcommand,
 			options: {

--- a/packages/documentation/src/commands/modifier/modifier.documentation.ts
+++ b/packages/documentation/src/commands/modifier/modifier.documentation.ts
@@ -138,8 +138,8 @@ export const modifierCommandDocumentation: CommandDocumentation<typeof modifierC
 					},
 				],
 			},
-			[ModifierSubCommandEnum.createModifier]: {
-				name: ModifierSubCommandEnum.createModifier,
+			[ModifierSubCommandEnum.create]: {
+				name: ModifierSubCommandEnum.create,
 				description: 'Creates a modifier for the active character.',
 				usage: null,
 				examples: [


### PR DESCRIPTION
…nventions and add modifier creation functionality

- Renamed `basicDamageDiceRoll` to `diceRoll` in action stage command options and related files.
- Updated references in action stage command documentation and definitions.
- Refactored condition command options to use `conditionName` and `modifierName` for better clarity.
- Renamed `ModifierCreateSubCommand`
- Adjusted various command definitions and documentation to reflect new naming and functionality.