### PR TITLE
refactor: rename gameplay command options for consistency and clarity

### DIFF
--- a/apps/kobold-client/src/commands/chat/game/game-create-subcommand.spec.ts
+++ b/apps/kobold-client/src/commands/chat/game/game-create-subcommand.spec.ts
@@ -40,7 +40,7 @@ describe('GameCreateSubCommand', () => {
 			commandName: 'game',
 			subcommand: 'create',
 			options: {
-				[opts.gameCreateName]: 'New Campaign',
+				[opts.createName]: 'New Campaign',
 			},
 			userId: TEST_USER_ID,
 			guildId: TEST_GUILD_ID,
@@ -71,7 +71,7 @@ describe('GameCreateSubCommand', () => {
 			commandName: 'game',
 			subcommand: 'create',
 			options: {
-				[opts.gameCreateName]: 'Existing Game',
+				[opts.createName]: 'Existing Game',
 			},
 			userId: TEST_USER_ID,
 			guildId: TEST_GUILD_ID,
@@ -92,7 +92,7 @@ describe('GameCreateSubCommand', () => {
 			commandName: 'game',
 			subcommand: 'create',
 			options: {
-				[opts.gameCreateName]: 'A',
+				[opts.createName]: 'A',
 			},
 			userId: TEST_USER_ID,
 			guildId: TEST_GUILD_ID,
@@ -115,7 +115,7 @@ describe('GameCreateSubCommand', () => {
 			commandName: 'game',
 			subcommand: 'create',
 			options: {
-				[opts.gameCreateName]: 'New Game',
+				[opts.createName]: 'New Game',
 			},
 			userId: TEST_USER_ID,
 			guildId: TEST_GUILD_ID,

--- a/apps/kobold-client/src/commands/chat/game/game-create-subcommand.ts
+++ b/apps/kobold-client/src/commands/chat/game/game-create-subcommand.ts
@@ -18,7 +18,7 @@ export class GameCreateSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<void> {
 		const gameName = intr.options.getString(
-			commandOptions[commandOptionsEnum.gameCreateName].name,
+			commandOptions[commandOptionsEnum.createName].name,
 			true
 		);
 

--- a/apps/kobold-client/src/commands/chat/game/game-delete-subcommand.spec.ts
+++ b/apps/kobold-client/src/commands/chat/game/game-delete-subcommand.spec.ts
@@ -15,7 +15,8 @@ import {
 	TEST_GUILD_ID,
 	CommandTestHarness,
 	getMockKobold,
-	resetMockKobold,} from '../../../test-utils/index.js';
+	resetMockKobold,
+} from '../../../test-utils/index.js';
 import { createMockGame } from './game-test-utils.js';
 
 describe('GameDeleteSubCommand', () => {
@@ -39,7 +40,7 @@ describe('GameDeleteSubCommand', () => {
 			commandName: 'game',
 			subcommand: 'delete',
 			options: {
-				[opts.gameTargetGame]: 'Doomed Game',
+				[opts.targetGame]: 'Doomed Game',
 			},
 			userId: TEST_USER_ID,
 			guildId: TEST_GUILD_ID,
@@ -62,7 +63,7 @@ describe('GameDeleteSubCommand', () => {
 			commandName: 'game',
 			subcommand: 'delete',
 			options: {
-				[opts.gameTargetGame]: 'Ghost Game',
+				[opts.targetGame]: 'Ghost Game',
 			},
 			userId: TEST_USER_ID,
 			guildId: TEST_GUILD_ID,

--- a/apps/kobold-client/src/commands/chat/game/game-delete-subcommand.ts
+++ b/apps/kobold-client/src/commands/chat/game/game-delete-subcommand.ts
@@ -25,7 +25,7 @@ export class GameDeleteSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<ApplicationCommandOptionChoiceData[] | undefined> {
 		if (!intr.isAutocomplete()) return;
-		if (option.name === commandOptions[commandOptionsEnum.gameTargetGame].name) {
+		if (option.name === commandOptions[commandOptionsEnum.targetGame].name) {
 			if (!intr.guildId) return [];
 
 			const value = (option.value as string).trim().toLowerCase();
@@ -50,7 +50,7 @@ export class GameDeleteSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<void> {
 		const gameName = intr.options.getString(
-			commandOptions[commandOptionsEnum.gameTargetGame].name,
+			commandOptions[commandOptionsEnum.targetGame].name,
 			true
 		);
 

--- a/apps/kobold-client/src/commands/chat/game/game-give-subcommand.spec.ts
+++ b/apps/kobold-client/src/commands/chat/game/game-give-subcommand.spec.ts
@@ -31,7 +31,6 @@ describe('GameGiveSubCommand Integration', () => {
 		harness = createTestHarness([new GameCommand([new GameGiveSubCommand()])]);
 	});
 
-
 	describe('Give Operations', () => {
 		it('should respond when giving temporary hit points', async () => {
 			// Arrange
@@ -45,8 +44,8 @@ describe('GameGiveSubCommand Integration', () => {
 				commandName: 'game',
 				subcommand: 'give',
 				options: {
-					[opts.gameGiveOption]: 'tempHp',
-					[opts.gameGiveAmount]: '10',
+					[opts.giveOption]: 'tempHp',
+					[opts.giveAmount]: '10',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -68,8 +67,8 @@ describe('GameGiveSubCommand Integration', () => {
 				commandName: 'game',
 				subcommand: 'give',
 				options: {
-					[opts.gameGiveOption]: 'hp',
-					[opts.gameGiveAmount]: '20',
+					[opts.giveOption]: 'hp',
+					[opts.giveAmount]: '20',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -91,8 +90,8 @@ describe('GameGiveSubCommand Integration', () => {
 				commandName: 'game',
 				subcommand: 'give',
 				options: {
-					[opts.gameGiveOption]: 'stamina',
-					[opts.gameGiveAmount]: '15',
+					[opts.giveOption]: 'stamina',
+					[opts.giveAmount]: '15',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -114,8 +113,8 @@ describe('GameGiveSubCommand Integration', () => {
 				commandName: 'game',
 				subcommand: 'give',
 				options: {
-					[opts.gameGiveOption]: 'resolve',
-					[opts.gameGiveAmount]: '5',
+					[opts.giveOption]: 'resolve',
+					[opts.giveAmount]: '5',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -137,8 +136,8 @@ describe('GameGiveSubCommand Integration', () => {
 				commandName: 'game',
 				subcommand: 'give',
 				options: {
-					[opts.gameGiveOption]: 'hp',
-					[opts.gameGiveAmount]: '10',
+					[opts.giveOption]: 'hp',
+					[opts.giveAmount]: '10',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -166,8 +165,8 @@ describe('GameGiveSubCommand Integration', () => {
 				commandName: 'game',
 				subcommand: 'give',
 				options: {
-					[opts.gameGiveOption]: 'tempHp',
-					[opts.gameGiveAmount]: '25',
+					[opts.giveOption]: 'tempHp',
+					[opts.giveAmount]: '25',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,

--- a/apps/kobold-client/src/commands/chat/game/game-give-subcommand.ts
+++ b/apps/kobold-client/src/commands/chat/game/game-give-subcommand.ts
@@ -28,11 +28,10 @@ export class GameGiveSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<ApplicationCommandOptionChoiceData[] | undefined> {
 		if (!intr.isAutocomplete()) return;
-		if (option.name === commandOptions[commandOptionsEnum.gameTargetCharacter].name) {
+		if (option.name === commandOptions[commandOptionsEnum.targetCharacter].name) {
 			const targetCharacter =
-				intr.options.getString(
-					commandOptions[commandOptionsEnum.gameTargetCharacter].name
-				) ?? '';
+				intr.options.getString(commandOptions[commandOptionsEnum.targetCharacter].name) ??
+				'';
 
 			const { gameUtils } = new KoboldUtils(kobold);
 			const activeGame = await gameUtils.getActiveGame(intr.user.id, intr.guildId ?? '');
@@ -45,15 +44,15 @@ export class GameGiveSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<void> {
 		const targetCharacterName = intr.options.getString(
-			commandOptions[commandOptionsEnum.gameTargetCharacter].name,
+			commandOptions[commandOptionsEnum.targetCharacter].name,
 			true
 		);
 		const option = _.camelCase(
-			intr.options.getString(commandOptions[commandOptionsEnum.gameGiveOption].name, true)
+			intr.options.getString(commandOptions[commandOptionsEnum.giveOption].name, true)
 		) as SheetBaseCounterKeys;
 
 		const unparsedValue = intr.options.getString(
-			commandOptions[commandOptionsEnum.gameGiveAmount].name,
+			commandOptions[commandOptionsEnum.giveAmount].name,
 			true
 		);
 		const value = `+${unparsedValue.trim()}`.replaceAll('++', '+').replaceAll('+-', '-');
@@ -102,7 +101,9 @@ export class GameGiveSubCommand extends BaseCommandClass(
 			let optionText = _.kebabCase(option).replaceAll('-', ' ');
 			if (optionText.charAt(optionText.length - 1) === 's')
 				optionText = optionText.slice(0, -1) + '(s)';
-			let message = `Yip! I gave ${updatedValue! - initialValue!} ${optionText} to ${character.name}! New total: ${updatedValue}`;
+			let message = `Yip! I gave ${updatedValue! - initialValue!} ${optionText} to ${
+				character.name
+			}! New total: ${updatedValue}`;
 			let maxValue = creature.sheet.baseCounters[option].max;
 			if (maxValue) message += `/${maxValue}`;
 

--- a/apps/kobold-client/src/commands/chat/game/game-init-subcommand.spec.ts
+++ b/apps/kobold-client/src/commands/chat/game/game-init-subcommand.spec.ts
@@ -19,7 +19,8 @@ import {
 	TEST_GUILD_ID,
 	CommandTestHarness,
 	getMockKobold,
-	resetMockKobold,} from '../../../test-utils/index.js';
+	resetMockKobold,
+} from '../../../test-utils/index.js';
 import { createMockGame, createMockInitiative } from './game-test-utils.js';
 import { KoboldUtils } from '../../../utils/kobold-service-utils/kobold-utils.js';
 
@@ -56,7 +57,7 @@ describe('GameInitSubCommand', () => {
 				commandName: 'game',
 				subcommand: 'init',
 				options: {
-					[opts.gameTargetCharacter]: 'All Players',
+					[opts.targetCharacter]: 'All Players',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -86,7 +87,7 @@ describe('GameInitSubCommand', () => {
 				commandName: 'game',
 				subcommand: 'init',
 				options: {
-					[opts.gameTargetCharacter]: 'Fighter',
+					[opts.targetCharacter]: 'Fighter',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -114,7 +115,7 @@ describe('GameInitSubCommand', () => {
 				commandName: 'game',
 				subcommand: 'init',
 				options: {
-					[opts.gameTargetCharacter]: 'All Players',
+					[opts.targetCharacter]: 'All Players',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -146,7 +147,7 @@ describe('GameInitSubCommand', () => {
 				commandName: 'game',
 				subcommand: 'init',
 				options: {
-					[opts.gameTargetCharacter]: 'All Players',
+					[opts.targetCharacter]: 'All Players',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -168,7 +169,7 @@ describe('GameInitSubCommand', () => {
 				commandName: 'game',
 				subcommand: 'init',
 				options: {
-					[opts.gameTargetCharacter]: 'All Players',
+					[opts.targetCharacter]: 'All Players',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,

--- a/apps/kobold-client/src/commands/chat/game/game-init-subcommand.ts
+++ b/apps/kobold-client/src/commands/chat/game/game-init-subcommand.ts
@@ -31,11 +31,10 @@ export class GameInitSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<ApplicationCommandOptionChoiceData[] | undefined> {
 		if (!intr.isAutocomplete()) return;
-		if (option.name === commandOptions[commandOptionsEnum.gameTargetCharacter].name) {
+		if (option.name === commandOptions[commandOptionsEnum.targetCharacter].name) {
 			const targetCharacter =
-				intr.options.getString(
-					commandOptions[commandOptionsEnum.gameTargetCharacter].name
-				) ?? '';
+				intr.options.getString(commandOptions[commandOptionsEnum.targetCharacter].name) ??
+				'';
 
 			const { gameUtils } = new KoboldUtils(kobold);
 			const activeGame = await gameUtils.getActiveGame(intr.user.id, intr.guildId ?? '');
@@ -101,7 +100,7 @@ export class GameInitSubCommand extends BaseCommandClass(
 			commandOptions[commandOptionsEnum.rollExpression].name
 		);
 		const targetCharacter = intr.options.getString(
-			commandOptions[commandOptionsEnum.gameTargetCharacter].name,
+			commandOptions[commandOptionsEnum.targetCharacter].name,
 			true
 		);
 

--- a/apps/kobold-client/src/commands/chat/game/game-join-subcommand.spec.ts
+++ b/apps/kobold-client/src/commands/chat/game/game-join-subcommand.spec.ts
@@ -17,7 +17,8 @@ import {
 	TEST_GUILD_ID,
 	CommandTestHarness,
 	getMockKobold,
-	resetMockKobold,} from '../../../test-utils/index.js';
+	resetMockKobold,
+} from '../../../test-utils/index.js';
 import { createMockGame } from './game-test-utils.js';
 import { KoboldUtils } from '../../../utils/kobold-service-utils/kobold-utils.js';
 
@@ -50,7 +51,7 @@ describe('GameJoinSubCommand', () => {
 			commandName: 'game',
 			subcommand: 'join',
 			options: {
-				[opts.gameTargetGame]: 'Adventure',
+				[opts.targetGame]: 'Adventure',
 			},
 			userId: TEST_USER_ID,
 			guildId: TEST_GUILD_ID,
@@ -73,7 +74,7 @@ describe('GameJoinSubCommand', () => {
 			commandName: 'game',
 			subcommand: 'join',
 			options: {
-				[opts.gameTargetGame]: 'Missing Game',
+				[opts.targetGame]: 'Missing Game',
 			},
 			userId: TEST_USER_ID,
 			guildId: TEST_GUILD_ID,
@@ -106,7 +107,7 @@ describe('GameJoinSubCommand', () => {
 			commandName: 'game',
 			subcommand: 'join',
 			options: {
-				[opts.gameTargetGame]: 'Adventure',
+				[opts.targetGame]: 'Adventure',
 			},
 			userId: TEST_USER_ID,
 			guildId: TEST_GUILD_ID,

--- a/apps/kobold-client/src/commands/chat/game/game-join-subcommand.ts
+++ b/apps/kobold-client/src/commands/chat/game/game-join-subcommand.ts
@@ -26,7 +26,7 @@ export class GameJoinSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<ApplicationCommandOptionChoiceData[] | undefined> {
 		if (!intr.isAutocomplete()) return;
-		if (option.name === commandOptions[commandOptionsEnum.gameTargetGame].name) {
+		if (option.name === commandOptions[commandOptionsEnum.targetGame].name) {
 			const value = (option.value as string).trim().toLowerCase();
 
 			const { gameUtils } = new KoboldUtils(kobold);
@@ -51,7 +51,7 @@ export class GameJoinSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<void> {
 		const gameName = intr.options.getString(
-			commandOptions[commandOptionsEnum.gameTargetGame].name,
+			commandOptions[commandOptionsEnum.targetGame].name,
 			true
 		);
 

--- a/apps/kobold-client/src/commands/chat/game/game-kick-subcommand.spec.ts
+++ b/apps/kobold-client/src/commands/chat/game/game-kick-subcommand.spec.ts
@@ -16,7 +16,8 @@ import {
 	TEST_GUILD_ID,
 	CommandTestHarness,
 	getMockKobold,
-	resetMockKobold,} from '../../../test-utils/index.js';
+	resetMockKobold,
+} from '../../../test-utils/index.js';
 import { createMockGame } from './game-test-utils.js';
 
 describe('GameKickSubCommand', () => {
@@ -47,8 +48,8 @@ describe('GameKickSubCommand', () => {
 			commandName: 'game',
 			subcommand: 'kick',
 			options: {
-				[opts.gameTargetGame]: 'Strict Game',
-				[opts.gameKickCharacter]: 'Troublemaker',
+				[opts.targetGame]: 'Strict Game',
+				[opts.targetCharacter]: 'Troublemaker',
 			},
 			userId: TEST_USER_ID,
 			guildId: TEST_GUILD_ID,
@@ -74,8 +75,8 @@ describe('GameKickSubCommand', () => {
 			commandName: 'game',
 			subcommand: 'kick',
 			options: {
-				[opts.gameTargetGame]: 'No Game',
-				[opts.gameKickCharacter]: 'Someone',
+				[opts.targetGame]: 'No Game',
+				[opts.targetCharacter]: 'Someone',
 			},
 			userId: TEST_USER_ID,
 			guildId: TEST_GUILD_ID,
@@ -99,8 +100,8 @@ describe('GameKickSubCommand', () => {
 			commandName: 'game',
 			subcommand: 'kick',
 			options: {
-				[opts.gameTargetGame]: 'Empty Kick Game',
-				[opts.gameKickCharacter]: 'Ghost',
+				[opts.targetGame]: 'Empty Kick Game',
+				[opts.targetCharacter]: 'Ghost',
 			},
 			userId: TEST_USER_ID,
 			guildId: TEST_GUILD_ID,

--- a/apps/kobold-client/src/commands/chat/game/game-kick-subcommand.ts
+++ b/apps/kobold-client/src/commands/chat/game/game-kick-subcommand.ts
@@ -28,7 +28,7 @@ export class GameKickSubCommand extends BaseCommandClass(
 
 		const value = (option.value as string).trim().toLowerCase();
 
-		if (option.name === commandOptions[commandOptionsEnum.gameTargetGame].name) {
+		if (option.name === commandOptions[commandOptionsEnum.targetGame].name) {
 			if (!intr.guildId) return [];
 
 			// Get games the user owns in this guild
@@ -45,12 +45,11 @@ export class GameKickSubCommand extends BaseCommandClass(
 				.filter(field => value === '' || field.name.toLowerCase().includes(value));
 		}
 
-		if (option.name === commandOptions[commandOptionsEnum.gameKickCharacter].name) {
+		if (option.name === commandOptions[commandOptionsEnum.targetCharacter].name) {
 			if (!intr.guildId) return [];
 
 			const selectedGameName =
-				intr.options.getString(commandOptions[commandOptionsEnum.gameTargetGame].name) ??
-				'';
+				intr.options.getString(commandOptions[commandOptionsEnum.targetGame].name) ?? '';
 
 			// Get the selected game
 			const targetGames = await kobold.game.readMany({
@@ -78,11 +77,11 @@ export class GameKickSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<void> {
 		const gameName = intr.options.getString(
-			commandOptions[commandOptionsEnum.gameTargetGame].name,
+			commandOptions[commandOptionsEnum.targetGame].name,
 			true
 		);
 		const characterName = intr.options.getString(
-			commandOptions[commandOptionsEnum.gameKickCharacter].name,
+			commandOptions[commandOptionsEnum.targetCharacter].name,
 			true
 		);
 

--- a/apps/kobold-client/src/commands/chat/game/game-leave-subcommand.spec.ts
+++ b/apps/kobold-client/src/commands/chat/game/game-leave-subcommand.spec.ts
@@ -17,7 +17,8 @@ import {
 	TEST_GUILD_ID,
 	CommandTestHarness,
 	getMockKobold,
-	resetMockKobold,} from '../../../test-utils/index.js';
+	resetMockKobold,
+} from '../../../test-utils/index.js';
 import { createMockGame } from './game-test-utils.js';
 import { KoboldUtils } from '../../../utils/kobold-service-utils/kobold-utils.js';
 
@@ -54,7 +55,7 @@ describe('GameLeaveSubCommand', () => {
 			commandName: 'game',
 			subcommand: 'leave',
 			options: {
-				[opts.gameTargetGame]: 'Adventure',
+				[opts.targetGame]: 'Adventure',
 			},
 			userId: TEST_USER_ID,
 			guildId: TEST_GUILD_ID,
@@ -77,7 +78,7 @@ describe('GameLeaveSubCommand', () => {
 			commandName: 'game',
 			subcommand: 'leave',
 			options: {
-				[opts.gameTargetGame]: 'Nowhere Game',
+				[opts.targetGame]: 'Nowhere Game',
 			},
 			userId: TEST_USER_ID,
 			guildId: TEST_GUILD_ID,
@@ -110,7 +111,7 @@ describe('GameLeaveSubCommand', () => {
 			commandName: 'game',
 			subcommand: 'leave',
 			options: {
-				[opts.gameTargetGame]: 'Adventure',
+				[opts.targetGame]: 'Adventure',
 			},
 			userId: TEST_USER_ID,
 			guildId: TEST_GUILD_ID,

--- a/apps/kobold-client/src/commands/chat/game/game-leave-subcommand.ts
+++ b/apps/kobold-client/src/commands/chat/game/game-leave-subcommand.ts
@@ -26,7 +26,7 @@ export class GameLeaveSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<ApplicationCommandOptionChoiceData[] | undefined> {
 		if (!intr.isAutocomplete()) return;
-		if (option.name === commandOptions[commandOptionsEnum.gameTargetGame].name) {
+		if (option.name === commandOptions[commandOptionsEnum.targetGame].name) {
 			const value = (option.value as string).trim().toLowerCase();
 
 			const { gameUtils } = new KoboldUtils(kobold);
@@ -51,7 +51,7 @@ export class GameLeaveSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<void> {
 		const gameName = intr.options.getString(
-			commandOptions[commandOptionsEnum.gameTargetGame].name,
+			commandOptions[commandOptionsEnum.targetGame].name,
 			true
 		);
 

--- a/apps/kobold-client/src/commands/chat/game/game-party-status-subcommand.ts
+++ b/apps/kobold-client/src/commands/chat/game/game-party-status-subcommand.ts
@@ -28,11 +28,10 @@ export class GamePartyStatusSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<ApplicationCommandOptionChoiceData[] | undefined> {
 		if (!intr.isAutocomplete()) return;
-		if (option.name === commandOptions[commandOptionsEnum.gameTargetCharacter].name) {
+		if (option.name === commandOptions[commandOptionsEnum.targetCharacter].name) {
 			const targetCharacter =
-				intr.options.getString(
-					commandOptions[commandOptionsEnum.gameTargetCharacter].name
-				) ?? '';
+				intr.options.getString(commandOptions[commandOptionsEnum.targetCharacter].name) ??
+				'';
 
 			const { gameUtils } = new KoboldUtils(kobold);
 			const activeGame = await gameUtils.getActiveGame(intr.user.id, intr.guildId ?? '');
@@ -45,10 +44,10 @@ export class GamePartyStatusSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<void> {
 		const sheetStyle =
-			intr.options.getString(commandOptions[commandOptionsEnum.gameSheetStyle].name) ??
+			intr.options.getString(commandOptions[commandOptionsEnum.sheetStyle].name) ??
 			SheetRecordTrackerModeEnum.counters_only;
 		const targetCharacterName = intr.options.getString(
-			commandOptions[commandOptionsEnum.gameTargetCharacter].name,
+			commandOptions[commandOptionsEnum.targetCharacter].name,
 			true
 		);
 		const koboldUtils = new KoboldUtils(kobold);

--- a/apps/kobold-client/src/commands/chat/game/game-roll-subcommand.spec.ts
+++ b/apps/kobold-client/src/commands/chat/game/game-roll-subcommand.spec.ts
@@ -31,7 +31,6 @@ describe('GameRollSubCommand Integration', () => {
 		harness = createTestHarness([new GameCommand([new GameRollSubCommand()])]);
 	});
 
-
 	describe('Dice Rolling', () => {
 		it('should respond when rolling dice for party characters', async () => {
 			// Arrange
@@ -49,9 +48,9 @@ describe('GameRollSubCommand Integration', () => {
 				commandName: 'game',
 				subcommand: 'roll',
 				options: {
-					[opts.gameRollType]: 'Dice',
-					[opts.gameTargetCharacter]: 'All Players',
-					[opts.gameDiceRollOrModifier]: '1d20',
+					[opts.rollType]: 'Dice',
+					[opts.targetCharacter]: 'All Players',
+					[opts.diceRollOrModifier]: '1d20',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -77,9 +76,9 @@ describe('GameRollSubCommand Integration', () => {
 				commandName: 'game',
 				subcommand: 'roll',
 				options: {
-					[opts.gameRollType]: 'Dice',
-					[opts.gameTargetCharacter]: 'All Players',
-					[opts.gameDiceRollOrModifier]: '2d6+5',
+					[opts.rollType]: 'Dice',
+					[opts.targetCharacter]: 'All Players',
+					[opts.diceRollOrModifier]: '2d6+5',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -108,9 +107,9 @@ describe('GameRollSubCommand Integration', () => {
 				commandName: 'game',
 				subcommand: 'roll',
 				options: {
-					[opts.gameRollType]: 'Dice',
-					[opts.gameTargetCharacter]: 'All Players',
-					[opts.gameDiceRollOrModifier]: '1d20',
+					[opts.rollType]: 'Dice',
+					[opts.targetCharacter]: 'All Players',
+					[opts.diceRollOrModifier]: '1d20',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -137,9 +136,9 @@ describe('GameRollSubCommand Integration', () => {
 				commandName: 'game',
 				subcommand: 'roll',
 				options: {
-					[opts.gameRollType]: 'Dice',
-					[opts.gameTargetCharacter]: 'Fighter',
-					[opts.gameDiceRollOrModifier]: '1d20',
+					[opts.rollType]: 'Dice',
+					[opts.targetCharacter]: 'Fighter',
+					[opts.diceRollOrModifier]: '1d20',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -166,9 +165,9 @@ describe('GameRollSubCommand Integration', () => {
 				commandName: 'game',
 				subcommand: 'roll',
 				options: {
-					[opts.gameRollType]: 'Dice',
-					[opts.gameTargetCharacter]: 'All Players',
-					[opts.gameDiceRollOrModifier]: '1d20',
+					[opts.rollType]: 'Dice',
+					[opts.targetCharacter]: 'All Players',
+					[opts.diceRollOrModifier]: '1d20',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -191,9 +190,9 @@ describe('GameRollSubCommand Integration', () => {
 				commandName: 'game',
 				subcommand: 'roll',
 				options: {
-					[opts.gameRollType]: 'Dice',
-					[opts.gameTargetCharacter]: 'All Players',
-					[opts.gameDiceRollOrModifier]: '1d20',
+					[opts.rollType]: 'Dice',
+					[opts.targetCharacter]: 'All Players',
+					[opts.diceRollOrModifier]: '1d20',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -221,9 +220,9 @@ describe('GameRollSubCommand Integration', () => {
 				commandName: 'game',
 				subcommand: 'roll',
 				options: {
-					[opts.gameRollType]: 'Dice',
-					[opts.gameTargetCharacter]: 'All Players',
-					[opts.gameDiceRollOrModifier]: '1d20',
+					[opts.rollType]: 'Dice',
+					[opts.targetCharacter]: 'All Players',
+					[opts.diceRollOrModifier]: '1d20',
 					'roll-secret': optionChoices.rollSecret.secret,
 				},
 				userId: TEST_USER_ID,
@@ -250,9 +249,9 @@ describe('GameRollSubCommand Integration', () => {
 				commandName: 'game',
 				subcommand: 'roll',
 				options: {
-					[opts.gameRollType]: 'Dice',
-					[opts.gameTargetCharacter]: 'All Players',
-					[opts.gameDiceRollOrModifier]: '1d20',
+					[opts.rollType]: 'Dice',
+					[opts.targetCharacter]: 'All Players',
+					[opts.diceRollOrModifier]: '1d20',
 					'roll-secret': optionChoices.rollSecret.sendToGm,
 				},
 				userId: TEST_USER_ID,
@@ -283,9 +282,9 @@ describe('GameRollSubCommand Integration', () => {
 				commandName: 'game',
 				subcommand: 'roll',
 				options: {
-					[opts.gameRollType]: 'Dice',
-					[opts.gameTargetCharacter]: 'All Players',
-					[opts.gameDiceRollOrModifier]: '1d20+10',
+					[opts.rollType]: 'Dice',
+					[opts.targetCharacter]: 'All Players',
+					[opts.diceRollOrModifier]: '1d20+10',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,

--- a/apps/kobold-client/src/commands/chat/game/game-roll-subcommand.ts
+++ b/apps/kobold-client/src/commands/chat/game/game-roll-subcommand.ts
@@ -31,19 +31,18 @@ export class GameRollSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<ApplicationCommandOptionChoiceData[] | undefined> {
 		if (!intr.isAutocomplete()) return;
-		if (option.name === commandOptions[commandOptionsEnum.gameTargetCharacter].name) {
+		if (option.name === commandOptions[commandOptionsEnum.targetCharacter].name) {
 			const targetCharacter =
-				intr.options.getString(
-					commandOptions[commandOptionsEnum.gameTargetCharacter].name
-				) ?? '';
+				intr.options.getString(commandOptions[commandOptionsEnum.targetCharacter].name) ??
+				'';
 
 			const { gameUtils } = new KoboldUtils(kobold);
 			const activeGame = await gameUtils.getActiveGame(intr.user.id, intr.guildId ?? '');
 			return gameUtils.autocompleteGameCharacter(targetCharacter, activeGame);
-		} else if (option.name === commandOptions[commandOptionsEnum.gameRollType].name) {
+		} else if (option.name === commandOptions[commandOptionsEnum.rollType].name) {
 			//we don't need to autocomplete if we're just dealing with whitespace
 			const match =
-				intr.options.getString(commandOptions[commandOptionsEnum.gameRollType].name) ?? '';
+				intr.options.getString(commandOptions[commandOptionsEnum.rollType].name) ?? '';
 
 			const { gameUtils } = new KoboldUtils(kobold);
 			const activeGame = await gameUtils.getActiveGame(intr.user.id, intr.guildId ?? '');
@@ -93,15 +92,14 @@ export class GameRollSubCommand extends BaseCommandClass(
 	): Promise<void> {
 		if (!intr.isChatInputCommand()) return;
 		const rollType = intr.options.getString(
-			commandOptions[commandOptionsEnum.gameRollType].name,
+			commandOptions[commandOptionsEnum.rollType].name,
 			true
 		);
 		const diceExpression =
-			intr.options.getString(
-				commandOptions[commandOptionsEnum.gameDiceRollOrModifier].name
-			) ?? '';
+			intr.options.getString(commandOptions[commandOptionsEnum.diceRollOrModifier].name) ??
+			'';
 		const targetCharacterName = intr.options.getString(
-			commandOptions[commandOptionsEnum.gameTargetCharacter].name,
+			commandOptions[commandOptionsEnum.targetCharacter].name,
 			true
 		);
 		const targetSheetName = intr.options.getString(

--- a/apps/kobold-client/src/commands/chat/game/game-set-active-subcommand.spec.ts
+++ b/apps/kobold-client/src/commands/chat/game/game-set-active-subcommand.spec.ts
@@ -15,7 +15,8 @@ import {
 	TEST_GUILD_ID,
 	CommandTestHarness,
 	getMockKobold,
-	resetMockKobold,} from '../../../test-utils/index.js';
+	resetMockKobold,
+} from '../../../test-utils/index.js';
 import { createMockGame } from './game-test-utils.js';
 
 describe('GameSetActiveSubCommand', () => {
@@ -40,7 +41,7 @@ describe('GameSetActiveSubCommand', () => {
 			commandName: 'game',
 			subcommand: 'set-active',
 			options: {
-				[opts.gameTargetGame]: 'Target Game',
+				[opts.targetGame]: 'Target Game',
 			},
 			userId: TEST_USER_ID,
 			guildId: TEST_GUILD_ID,
@@ -63,7 +64,7 @@ describe('GameSetActiveSubCommand', () => {
 			commandName: 'game',
 			subcommand: 'set-active',
 			options: {
-				[opts.gameTargetGame]: 'Nonexistent Game',
+				[opts.targetGame]: 'Nonexistent Game',
 			},
 			userId: TEST_USER_ID,
 			guildId: TEST_GUILD_ID,
@@ -86,7 +87,7 @@ describe('GameSetActiveSubCommand', () => {
 			commandName: 'game',
 			subcommand: 'set-active',
 			options: {
-				[opts.gameTargetGame]: 'Target Game',
+				[opts.targetGame]: 'Target Game',
 			},
 			userId: TEST_USER_ID,
 			guildId: TEST_GUILD_ID,

--- a/apps/kobold-client/src/commands/chat/game/game-set-active-subcommand.ts
+++ b/apps/kobold-client/src/commands/chat/game/game-set-active-subcommand.ts
@@ -25,7 +25,7 @@ export class GameSetActiveSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<ApplicationCommandOptionChoiceData[] | undefined> {
 		if (!intr.isAutocomplete()) return;
-		if (option.name === commandOptions[commandOptionsEnum.gameTargetGame].name) {
+		if (option.name === commandOptions[commandOptionsEnum.targetGame].name) {
 			if (!intr.guildId) return [];
 
 			const value = (option.value as string).trim().toLowerCase();
@@ -50,7 +50,7 @@ export class GameSetActiveSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<void> {
 		const gameName = intr.options.getString(
-			commandOptions[commandOptionsEnum.gameTargetGame].name,
+			commandOptions[commandOptionsEnum.targetGame].name,
 			true
 		);
 

--- a/apps/kobold-client/src/commands/chat/gameplay/gameplay-damage-subcommand.spec.ts
+++ b/apps/kobold-client/src/commands/chat/gameplay/gameplay-damage-subcommand.spec.ts
@@ -29,7 +29,6 @@ describe('GameplayDamageSubCommand Integration', () => {
 		harness = createTestHarness([new GameplayCommand([new GameplayDamageSubCommand()])]);
 	});
 
-
 	describe('Damage Application', () => {
 		it('should respond when applying damage', async () => {
 			// Arrange
@@ -42,8 +41,8 @@ describe('GameplayDamageSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'damage',
 				options: {
-					[opts.gameplayTargetCharacter]: 'Fighter',
-					[opts.gameplayDamageAmount]: 10,
+					[opts.targetCharacter]: 'Fighter',
+					[opts.damageAmount]: 10,
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -64,9 +63,9 @@ describe('GameplayDamageSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'damage',
 				options: {
-					[opts.gameplayTargetCharacter]: 'Wizard',
-					[opts.gameplayDamageAmount]: 15,
-					[opts.gameplayDamageType]: 'fire',
+					[opts.targetCharacter]: 'Wizard',
+					[opts.damageAmount]: 15,
+					[opts.damageType]: 'fire',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -89,8 +88,8 @@ describe('GameplayDamageSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'damage',
 				options: {
-					[opts.gameplayTargetCharacter]: 'Barbarian',
-					[opts.gameplayDamageAmount]: 100,
+					[opts.targetCharacter]: 'Barbarian',
+					[opts.damageAmount]: 100,
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -113,8 +112,8 @@ describe('GameplayDamageSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'damage',
 				options: {
-					[opts.gameplayTargetCharacter]: 'Cleric',
-					[opts.gameplayDamageAmount]: -20,
+					[opts.targetCharacter]: 'Cleric',
+					[opts.damageAmount]: -20,
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -137,9 +136,9 @@ describe('GameplayDamageSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'damage',
 				options: {
-					[opts.gameplayTargetCharacter]: 'Target',
-					[opts.gameplayDamageAmount]: 8,
-					[opts.gameplayDamageType]: 'slashing',
+					[opts.targetCharacter]: 'Target',
+					[opts.damageAmount]: 8,
+					[opts.damageType]: 'slashing',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -160,9 +159,9 @@ describe('GameplayDamageSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'damage',
 				options: {
-					[opts.gameplayTargetCharacter]: 'Target',
-					[opts.gameplayDamageAmount]: 12,
-					[opts.gameplayDamageType]: 'cold',
+					[opts.targetCharacter]: 'Target',
+					[opts.damageAmount]: 12,
+					[opts.damageType]: 'cold',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -184,8 +183,8 @@ describe('GameplayDamageSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'damage',
 				options: {
-					[opts.gameplayTargetCharacter]: 'NonexistentTarget',
-					[opts.gameplayDamageAmount]: 10,
+					[opts.targetCharacter]: 'NonexistentTarget',
+					[opts.damageAmount]: 10,
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,

--- a/apps/kobold-client/src/commands/chat/gameplay/gameplay-damage-subcommand.ts
+++ b/apps/kobold-client/src/commands/chat/gameplay/gameplay-damage-subcommand.ts
@@ -27,11 +27,10 @@ export class GameplayDamageSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<ApplicationCommandOptionChoiceData[] | undefined> {
 		if (!intr.isAutocomplete()) return;
-		if (option.name === commandOptions[commandOptionsEnum.gameplayTargetCharacter].name) {
+		if (option.name === commandOptions[commandOptionsEnum.targetCharacter].name) {
 			const match =
-				intr.options.getString(
-					commandOptions[commandOptionsEnum.gameplayTargetCharacter].name
-				) ?? '';
+				intr.options.getString(commandOptions[commandOptionsEnum.targetCharacter].name) ??
+				'';
 			const { autocompleteUtils } = new KoboldUtils(kobold);
 			return await autocompleteUtils.getAllTargetOptions(intr, match);
 		}
@@ -42,16 +41,14 @@ export class GameplayDamageSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<void> {
 		const targetCharacter = intr.options.getString(
-			commandOptions[commandOptionsEnum.gameplayTargetCharacter].name,
+			commandOptions[commandOptionsEnum.targetCharacter].name,
 			true
 		);
 		const amount = intr.options.getNumber(
-			commandOptions[commandOptionsEnum.gameplayDamageAmount].name,
+			commandOptions[commandOptionsEnum.damageAmount].name,
 			true
 		);
-		const type = intr.options.getString(
-			commandOptions[commandOptionsEnum.gameplayDamageType].name
-		);
+		const type = intr.options.getString(commandOptions[commandOptionsEnum.damageType].name);
 
 		const { gameUtils, creatureUtils } = new KoboldUtils(kobold);
 

--- a/apps/kobold-client/src/commands/chat/gameplay/gameplay-recover-subcommand.spec.ts
+++ b/apps/kobold-client/src/commands/chat/gameplay/gameplay-recover-subcommand.spec.ts
@@ -29,7 +29,6 @@ describe('GameplayRecoverSubCommand Integration', () => {
 		harness = createTestHarness([new GameplayCommand([new GameplayRecoverSubCommand()])]);
 	});
 
-
 	describe('Stat Recovery', () => {
 		it('should respond when recovering stats', async () => {
 			// Arrange
@@ -42,7 +41,7 @@ describe('GameplayRecoverSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'recover',
 				options: {
-					[opts.gameplayTargetCharacter]: 'Warrior',
+					[opts.targetCharacter]: 'Warrior',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -65,7 +64,7 @@ describe('GameplayRecoverSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'recover',
 				options: {
-					[opts.gameplayTargetCharacter]: 'FullHealth',
+					[opts.targetCharacter]: 'FullHealth',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -111,7 +110,7 @@ describe('GameplayRecoverSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'recover',
 				options: {
-					[opts.gameplayTargetCharacter]: 'NamedTarget',
+					[opts.targetCharacter]: 'NamedTarget',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -133,7 +132,7 @@ describe('GameplayRecoverSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'recover',
 				options: {
-					[opts.gameplayTargetCharacter]: 'MissingCharacter',
+					[opts.targetCharacter]: 'MissingCharacter',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,

--- a/apps/kobold-client/src/commands/chat/gameplay/gameplay-recover-subcommand.ts
+++ b/apps/kobold-client/src/commands/chat/gameplay/gameplay-recover-subcommand.ts
@@ -26,7 +26,7 @@ export class GameplayRecoverSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<ApplicationCommandOptionChoiceData[] | undefined> {
 		if (!intr.isAutocomplete()) return;
-		if (option.name === commandOptions[commandOptionsEnum.gameplayTargetCharacter].name) {
+		if (option.name === commandOptions[commandOptionsEnum.targetCharacter].name) {
 			const { autocompleteUtils } = new KoboldUtils(kobold);
 			return await autocompleteUtils.getAllTargetOptions(intr, option.value);
 		}
@@ -37,7 +37,7 @@ export class GameplayRecoverSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: any }
 	): Promise<void> {
 		const targetCharacter = intr.options.getString(
-			commandOptions[commandOptionsEnum.gameplayTargetCharacter].name,
+			commandOptions[commandOptionsEnum.targetCharacter].name,
 			true
 		);
 

--- a/apps/kobold-client/src/commands/chat/gameplay/gameplay-set-subcommand.spec.ts
+++ b/apps/kobold-client/src/commands/chat/gameplay/gameplay-set-subcommand.spec.ts
@@ -29,7 +29,6 @@ describe('GameplaySetSubCommand Integration', () => {
 		harness = createTestHarness([new GameplayCommand([new GameplaySetSubCommand()])]);
 	});
 
-
 	describe('Setting HP', () => {
 		it('should respond when setting hp', async () => {
 			// Arrange
@@ -42,9 +41,9 @@ describe('GameplaySetSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'set',
 				options: {
-					[opts.gameplayTargetCharacter]: 'Fighter',
-					[opts.gameplaySetOption]: 'hp',
-					[opts.gameplaySetValue]: 50,
+					[opts.targetCharacter]: 'Fighter',
+					[opts.setOption]: 'hp',
+					[opts.setValue]: 50,
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -65,9 +64,9 @@ describe('GameplaySetSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'set',
 				options: {
-					[opts.gameplayTargetCharacter]: 'Warrior',
-					[opts.gameplaySetOption]: 'hp',
-					[opts.gameplaySetValue]: 0,
+					[opts.targetCharacter]: 'Warrior',
+					[opts.setOption]: 'hp',
+					[opts.setValue]: 0,
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -92,9 +91,9 @@ describe('GameplaySetSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'set',
 				options: {
-					[opts.gameplayTargetCharacter]: 'Barbarian',
-					[opts.gameplaySetOption]: 'temp-hp',
-					[opts.gameplaySetValue]: 15,
+					[opts.targetCharacter]: 'Barbarian',
+					[opts.setOption]: 'temp-hp',
+					[opts.setValue]: 15,
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -117,9 +116,9 @@ describe('GameplaySetSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'set',
 				options: {
-					[opts.gameplayTargetCharacter]: 'Champion',
-					[opts.gameplaySetOption]: 'stamina',
-					[opts.gameplaySetValue]: 10,
+					[opts.targetCharacter]: 'Champion',
+					[opts.setOption]: 'stamina',
+					[opts.setValue]: 10,
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -142,9 +141,9 @@ describe('GameplaySetSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'set',
 				options: {
-					[opts.gameplayTargetCharacter]: 'Paladin',
-					[opts.gameplaySetOption]: 'resolve',
-					[opts.gameplaySetValue]: 3,
+					[opts.targetCharacter]: 'Paladin',
+					[opts.setOption]: 'resolve',
+					[opts.setValue]: 3,
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -167,9 +166,9 @@ describe('GameplaySetSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'set',
 				options: {
-					[opts.gameplayTargetCharacter]: 'Rogue',
-					[opts.gameplaySetOption]: 'hero-points',
-					[opts.gameplaySetValue]: 2,
+					[opts.targetCharacter]: 'Rogue',
+					[opts.setOption]: 'hero-points',
+					[opts.setValue]: 2,
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -192,9 +191,9 @@ describe('GameplaySetSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'set',
 				options: {
-					[opts.gameplayTargetCharacter]: 'Monk',
-					[opts.gameplaySetOption]: 'focus-points',
-					[opts.gameplaySetValue]: 1,
+					[opts.targetCharacter]: 'Monk',
+					[opts.setOption]: 'focus-points',
+					[opts.setValue]: 1,
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -216,9 +215,9 @@ describe('GameplaySetSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'set',
 				options: {
-					[opts.gameplayTargetCharacter]: 'GhostCharacter',
-					[opts.gameplaySetOption]: 'hp',
-					[opts.gameplaySetValue]: 50,
+					[opts.targetCharacter]: 'GhostCharacter',
+					[opts.setOption]: 'hp',
+					[opts.setValue]: 50,
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,

--- a/apps/kobold-client/src/commands/chat/gameplay/gameplay-set-subcommand.ts
+++ b/apps/kobold-client/src/commands/chat/gameplay/gameplay-set-subcommand.ts
@@ -28,7 +28,7 @@ export class GameplaySetSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<ApplicationCommandOptionChoiceData[] | undefined> {
 		if (!intr.isAutocomplete()) return;
-		if (option.name === commandOptions[commandOptionsEnum.gameplayTargetCharacter].name) {
+		if (option.name === commandOptions[commandOptionsEnum.targetCharacter].name) {
 			const { autocompleteUtils } = new KoboldUtils(kobold);
 			return await autocompleteUtils.getAllTargetOptions(intr, option.value);
 		}
@@ -39,15 +39,15 @@ export class GameplaySetSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: any }
 	): Promise<void> {
 		const targetCharacter = intr.options.getString(
-			commandOptions[commandOptionsEnum.gameplayTargetCharacter].name,
+			commandOptions[commandOptionsEnum.targetCharacter].name,
 			true
 		);
 		const option = _.camelCase(
-			intr.options.getString(commandOptions[commandOptionsEnum.gameplaySetOption].name, true)
+			intr.options.getString(commandOptions[commandOptionsEnum.setOption].name, true)
 		) as SheetBaseCounterKeys;
 
 		const value = intr.options.getString(
-			commandOptions[commandOptionsEnum.gameplaySetValue].name,
+			commandOptions[commandOptionsEnum.setValue].name,
 			true
 		);
 

--- a/apps/kobold-client/src/commands/chat/gameplay/gameplay-tracker-subcommand.spec.ts
+++ b/apps/kobold-client/src/commands/chat/gameplay/gameplay-tracker-subcommand.spec.ts
@@ -30,7 +30,6 @@ describe('GameplayTrackerSubCommand Integration', () => {
 		harness = createTestHarness([new GameplayCommand([new GameplayTrackerSubCommand()])]);
 	});
 
-
 	describe('Tracker Creation', () => {
 		it('should respond when creating a basic tracker', async () => {
 			// Arrange
@@ -45,7 +44,7 @@ describe('GameplayTrackerSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'tracker',
 				options: {
-					[opts.gameplayTargetCharacter]: 'TrackerChar',
+					[opts.targetCharacter]: 'TrackerChar',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -91,8 +90,8 @@ describe('GameplayTrackerSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'tracker',
 				options: {
-					[opts.gameplayTargetCharacter]: 'CountersChar',
-					[opts.gameplayTrackerMode]: 'counters_only',
+					[opts.targetCharacter]: 'CountersChar',
+					[opts.trackerMode]: 'counters_only',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -115,8 +114,8 @@ describe('GameplayTrackerSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'tracker',
 				options: {
-					[opts.gameplayTargetCharacter]: 'BasicChar',
-					[opts.gameplayTrackerMode]: 'basic_stats',
+					[opts.targetCharacter]: 'BasicChar',
+					[opts.trackerMode]: 'basic_stats',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -139,8 +138,8 @@ describe('GameplayTrackerSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'tracker',
 				options: {
-					[opts.gameplayTargetCharacter]: 'FullSheetChar',
-					[opts.gameplayTrackerMode]: 'full_sheet',
+					[opts.targetCharacter]: 'FullSheetChar',
+					[opts.trackerMode]: 'full_sheet',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -165,8 +164,8 @@ describe('GameplayTrackerSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'tracker',
 				options: {
-					[opts.gameplayTargetCharacter]: 'ChannelChar',
-					[opts.gameplayTargetChannel]: TEST_CHANNEL_ID,
+					[opts.targetCharacter]: 'ChannelChar',
+					[opts.targetChannel]: TEST_CHANNEL_ID,
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -189,9 +188,9 @@ describe('GameplayTrackerSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'tracker',
 				options: {
-					[opts.gameplayTargetCharacter]: 'ModeChannelChar',
-					[opts.gameplayTrackerMode]: 'basic_stats',
-					[opts.gameplayTargetChannel]: TEST_CHANNEL_ID,
+					[opts.targetCharacter]: 'ModeChannelChar',
+					[opts.trackerMode]: 'basic_stats',
+					[opts.targetChannel]: TEST_CHANNEL_ID,
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -221,7 +220,7 @@ describe('GameplayTrackerSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'tracker',
 				options: {
-					[opts.gameplayTargetCharacter]: 'ExistingTrackerChar',
+					[opts.targetCharacter]: 'ExistingTrackerChar',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,
@@ -243,7 +242,7 @@ describe('GameplayTrackerSubCommand Integration', () => {
 				commandName: 'gameplay',
 				subcommand: 'tracker',
 				options: {
-					[opts.gameplayTargetCharacter]: 'MissingCharacter',
+					[opts.targetCharacter]: 'MissingCharacter',
 				},
 				userId: TEST_USER_ID,
 				guildId: TEST_GUILD_ID,

--- a/apps/kobold-client/src/commands/chat/gameplay/gameplay-tracker-subcommand.ts
+++ b/apps/kobold-client/src/commands/chat/gameplay/gameplay-tracker-subcommand.ts
@@ -34,11 +34,10 @@ export class GameplayTrackerSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<ApplicationCommandOptionChoiceData[] | undefined> {
 		if (!intr.isAutocomplete()) return;
-		if (option.name === commandOptions[commandOptionsEnum.gameplayTargetCharacter].name) {
+		if (option.name === commandOptions[commandOptionsEnum.targetCharacter].name) {
 			const match =
-				intr.options.getString(
-					commandOptions[commandOptionsEnum.gameplayTargetCharacter].name
-				) ?? '';
+				intr.options.getString(commandOptions[commandOptionsEnum.targetCharacter].name) ??
+				'';
 
 			//get the character matches
 			const { characterUtils } = new KoboldUtils(kobold);
@@ -57,13 +56,13 @@ export class GameplayTrackerSubCommand extends BaseCommandClass(
 		{ kobold }: { kobold: Kobold }
 	): Promise<void> {
 		const targetCharacterName = intr.options.getString(
-			commandOptions[commandOptionsEnum.gameplayTargetCharacter].name
+			commandOptions[commandOptionsEnum.targetCharacter].name
 		);
 		const trackerMode =
-			intr.options.getString(commandOptions[commandOptionsEnum.gameplayTrackerMode].name) ??
+			intr.options.getString(commandOptions[commandOptionsEnum.trackerMode].name) ??
 			SheetRecordTrackerModeEnum.basic_stats;
 		const gameplayTargetChannel = intr.options.getChannel(
-			commandOptions[commandOptionsEnum.gameplayTargetChannel].name,
+			commandOptions[commandOptionsEnum.targetChannel].name,
 			false,
 			[ChannelType.GuildText]
 		);

--- a/packages/documentation/src/commands/character/character.command-options.ts
+++ b/packages/documentation/src/commands/character/character.command-options.ts
@@ -9,7 +9,7 @@ export enum CharacterCommandOptionEnum {
 	useStamina = 'use-stamina',
 	name = 'name',
 	id = 'id',
-	sheetStyle = 'game-sheet-style',
+	sheetStyle = 'sheet-style',
 }
 
 export enum CharacterSetDefaultScopeOptionsEnum {

--- a/packages/documentation/src/commands/counter/counter.command-definition.ts
+++ b/packages/documentation/src/commands/counter/counter.command-definition.ts
@@ -43,11 +43,9 @@ export const counterCommandDefinition = {
 			type: ApplicationCommandType.ChatInput,
 			options: {
 				[CounterCommandOptionEnum.counterName]: withOrder(
-					{
-						...counterCommandOptions[CounterCommandOptionEnum.counterName],
-						autocomplete: true,
-						choices: undefined,
-					} as APIApplicationCommandOption,
+					counterCommandOptions[
+						CounterCommandOptionEnum.counterName
+					] as APIApplicationCommandOption,
 					1
 				),
 			},
@@ -58,11 +56,9 @@ export const counterCommandDefinition = {
 			type: ApplicationCommandType.ChatInput,
 			options: {
 				[CounterCommandOptionEnum.counterName]: withOrder(
-					{
-						...counterCommandOptions[CounterCommandOptionEnum.counterName],
-						autocomplete: true,
-						choices: undefined,
-					} as APIApplicationCommandOption,
+					counterCommandOptions[
+						CounterCommandOptionEnum.counterName
+					] as APIApplicationCommandOption,
 					1
 				),
 			},
@@ -73,11 +69,9 @@ export const counterCommandDefinition = {
 			type: ApplicationCommandType.ChatInput,
 			options: {
 				[CounterCommandOptionEnum.counterName]: withOrder(
-					{
-						...counterCommandOptions[CounterCommandOptionEnum.counterName],
-						autocomplete: true,
-						choices: undefined,
-					} as APIApplicationCommandOption,
+					counterCommandOptions[
+						CounterCommandOptionEnum.counterName
+					] as APIApplicationCommandOption,
 					1
 				),
 				[CounterCommandOptionEnum.counterSlot]: withOrder(
@@ -96,11 +90,9 @@ export const counterCommandDefinition = {
 			type: ApplicationCommandType.ChatInput,
 			options: {
 				[CounterCommandOptionEnum.counterName]: withOrder(
-					{
-						...counterCommandOptions[CounterCommandOptionEnum.counterName],
-						autocomplete: true,
-						choices: undefined,
-					} as APIApplicationCommandOption,
+					counterCommandOptions[
+						CounterCommandOptionEnum.counterName
+					] as APIApplicationCommandOption,
 					1
 				),
 				[CounterCommandOptionEnum.counterValue]: withOrder(
@@ -115,11 +107,9 @@ export const counterCommandDefinition = {
 			type: ApplicationCommandType.ChatInput,
 			options: {
 				[CounterCommandOptionEnum.counterName]: withOrder(
-					{
-						...counterCommandOptions[CounterCommandOptionEnum.counterName],
-						autocomplete: true,
-						choices: undefined,
-					} as APIApplicationCommandOption,
+					counterCommandOptions[
+						CounterCommandOptionEnum.counterName
+					] as APIApplicationCommandOption,
 					1
 				),
 				[CounterCommandOptionEnum.counterSlot]: withOrder(
@@ -138,11 +128,9 @@ export const counterCommandDefinition = {
 			type: ApplicationCommandType.ChatInput,
 			options: {
 				[CounterCommandOptionEnum.counterName]: withOrder(
-					{
-						...counterCommandOptions[CounterCommandOptionEnum.counterName],
-						autocomplete: true,
-						choices: undefined,
-					} as APIApplicationCommandOption,
+					counterCommandOptions[
+						CounterCommandOptionEnum.counterName
+					] as APIApplicationCommandOption,
 					1
 				),
 				[CounterCommandOptionEnum.counterPrepareMany]: withOrder(
@@ -165,7 +153,10 @@ export const counterCommandDefinition = {
 					1
 				),
 				[CounterCommandOptionEnum.counterName]: withOrder(
-					counterCommandOptions[CounterCommandOptionEnum.counterName],
+					{
+						...counterCommandOptions[CounterCommandOptionEnum.counterName],
+						autocomplete: false,
+					},
 					2
 				),
 				[CounterCommandOptionEnum.counterMax]: withOrder(
@@ -192,11 +183,9 @@ export const counterCommandDefinition = {
 			type: ApplicationCommandType.ChatInput,
 			options: {
 				[CounterCommandOptionEnum.counterName]: withOrder(
-					{
-						...counterCommandOptions[CounterCommandOptionEnum.counterName],
-						autocomplete: true,
-						choices: undefined,
-					} as APIApplicationCommandOption,
+					counterCommandOptions[
+						CounterCommandOptionEnum.counterName
+					] as APIApplicationCommandOption,
 					1
 				),
 				[CounterCommandOptionEnum.counterSetOption]: withOrder(
@@ -215,11 +204,9 @@ export const counterCommandDefinition = {
 			type: ApplicationCommandType.ChatInput,
 			options: {
 				[CounterCommandOptionEnum.counterName]: withOrder(
-					{
-						...counterCommandOptions[CounterCommandOptionEnum.counterName],
-						autocomplete: true,
-						choices: undefined,
-					} as APIApplicationCommandOption,
+					counterCommandOptions[
+						CounterCommandOptionEnum.counterName
+					] as APIApplicationCommandOption,
 					1
 				),
 			},

--- a/packages/documentation/src/commands/counter/counter.command-options.ts
+++ b/packages/documentation/src/commands/counter/counter.command-options.ts
@@ -48,6 +48,8 @@ export const counterCommandOptions = {
 	[CounterCommandOptionEnum.counterName]: {
 		name: CounterCommandOptionEnum.counterName,
 		description: 'The name of the counter.',
+		autocomplete: true,
+		choices: undefined,
 		required: true,
 		type: ApplicationCommandOptionType.String,
 	},

--- a/packages/documentation/src/commands/game/game.command-definition.ts
+++ b/packages/documentation/src/commands/game/game.command-definition.ts
@@ -32,8 +32,8 @@ export const gameCommandDefinition = {
 			description: 'Create a new game in this server.',
 			type: ApplicationCommandOptionType.Subcommand,
 			options: {
-				[GameCommandOptionEnum.gameCreateName]: withOrder(
-					gameCommandOptions[GameCommandOptionEnum.gameCreateName],
+				[GameCommandOptionEnum.createName]: withOrder(
+					gameCommandOptions[GameCommandOptionEnum.createName],
 					1
 				),
 			},
@@ -43,8 +43,8 @@ export const gameCommandDefinition = {
 			description: 'Join your active character to a game.',
 			type: ApplicationCommandOptionType.Subcommand,
 			options: {
-				[GameCommandOptionEnum.gameTargetGame]: withOrder(
-					gameCommandOptions[GameCommandOptionEnum.gameTargetGame],
+				[GameCommandOptionEnum.targetGame]: withOrder(
+					gameCommandOptions[GameCommandOptionEnum.targetGame],
 					1
 				),
 			},
@@ -54,8 +54,8 @@ export const gameCommandDefinition = {
 			description: 'Set a game as your active game in this server.',
 			type: ApplicationCommandOptionType.Subcommand,
 			options: {
-				[GameCommandOptionEnum.gameTargetGame]: withOrder(
-					gameCommandOptions[GameCommandOptionEnum.gameTargetGame],
+				[GameCommandOptionEnum.targetGame]: withOrder(
+					gameCommandOptions[GameCommandOptionEnum.targetGame],
 					1
 				),
 			},
@@ -65,8 +65,8 @@ export const gameCommandDefinition = {
 			description: 'Remove your active character from a game.',
 			type: ApplicationCommandOptionType.Subcommand,
 			options: {
-				[GameCommandOptionEnum.gameTargetGame]: withOrder(
-					gameCommandOptions[GameCommandOptionEnum.gameTargetGame],
+				[GameCommandOptionEnum.targetGame]: withOrder(
+					gameCommandOptions[GameCommandOptionEnum.targetGame],
 					1
 				),
 			},
@@ -76,12 +76,12 @@ export const gameCommandDefinition = {
 			description: 'Kick a character from your game. GM only.',
 			type: ApplicationCommandOptionType.Subcommand,
 			options: {
-				[GameCommandOptionEnum.gameTargetGame]: withOrder(
-					gameCommandOptions[GameCommandOptionEnum.gameTargetGame],
+				[GameCommandOptionEnum.targetGame]: withOrder(
+					gameCommandOptions[GameCommandOptionEnum.targetGame],
 					1
 				),
-				[GameCommandOptionEnum.gameKickCharacter]: withOrder(
-					gameCommandOptions[GameCommandOptionEnum.gameKickCharacter],
+				[GameCommandOptionEnum.targetCharacter]: withOrder(
+					gameCommandOptions[GameCommandOptionEnum.targetCharacter],
 					2
 				),
 			},
@@ -91,8 +91,8 @@ export const gameCommandDefinition = {
 			description: 'Delete a game you created. GM only.',
 			type: ApplicationCommandOptionType.Subcommand,
 			options: {
-				[GameCommandOptionEnum.gameTargetGame]: withOrder(
-					gameCommandOptions[GameCommandOptionEnum.gameTargetGame],
+				[GameCommandOptionEnum.targetGame]: withOrder(
+					gameCommandOptions[GameCommandOptionEnum.targetGame],
 					1
 				),
 			},
@@ -103,8 +103,8 @@ export const gameCommandDefinition = {
 				'Starts initiative and adds joins with all characters in the game. GM only.',
 			type: ApplicationCommandOptionType.Subcommand,
 			options: {
-				[GameCommandOptionEnum.gameTargetCharacter]: withOrder(
-					gameCommandOptions[GameCommandOptionEnum.gameTargetCharacter],
+				[GameCommandOptionEnum.targetCharacter]: withOrder(
+					gameCommandOptions[GameCommandOptionEnum.targetCharacter],
 					1
 				),
 				[GameCommandOptionEnum.skillChoice]: withOrder(
@@ -136,12 +136,12 @@ export const gameCommandDefinition = {
 			description: 'Displays the status of all party members.',
 			type: ApplicationCommandOptionType.Subcommand,
 			options: {
-				[GameCommandOptionEnum.gameTargetCharacter]: withOrder(
-					gameCommandOptions[GameCommandOptionEnum.gameTargetCharacter],
+				[GameCommandOptionEnum.targetCharacter]: withOrder(
+					gameCommandOptions[GameCommandOptionEnum.targetCharacter],
 					1
 				),
-				[GameCommandOptionEnum.gameSheetStyle]: withOrder(
-					gameCommandOptions[GameCommandOptionEnum.gameSheetStyle],
+				[GameCommandOptionEnum.sheetStyle]: withOrder(
+					gameCommandOptions[GameCommandOptionEnum.sheetStyle],
 					2
 				),
 			},
@@ -151,16 +151,16 @@ export const gameCommandDefinition = {
 			description: 'Gives certain resources to players in the game.',
 			type: ApplicationCommandOptionType.Subcommand,
 			options: {
-				[GameCommandOptionEnum.gameTargetCharacter]: withOrder(
-					gameCommandOptions[GameCommandOptionEnum.gameTargetCharacter],
+				[GameCommandOptionEnum.targetCharacter]: withOrder(
+					gameCommandOptions[GameCommandOptionEnum.targetCharacter],
 					1
 				),
-				[GameCommandOptionEnum.gameGiveOption]: withOrder(
-					gameCommandOptions[GameCommandOptionEnum.gameGiveOption],
+				[GameCommandOptionEnum.giveOption]: withOrder(
+					gameCommandOptions[GameCommandOptionEnum.giveOption],
 					2
 				),
-				[GameCommandOptionEnum.gameGiveAmount]: withOrder(
-					gameCommandOptions[GameCommandOptionEnum.gameGiveAmount],
+				[GameCommandOptionEnum.giveAmount]: withOrder(
+					gameCommandOptions[GameCommandOptionEnum.giveAmount],
 					3
 				),
 			},
@@ -170,16 +170,16 @@ export const gameCommandDefinition = {
 			description: 'Rolls dice for all characters in a game (or optionally one). GM only.',
 			type: ApplicationCommandOptionType.Subcommand,
 			options: {
-				[GameCommandOptionEnum.gameTargetCharacter]: withOrder(
-					gameCommandOptions[GameCommandOptionEnum.gameTargetCharacter],
+				[GameCommandOptionEnum.targetCharacter]: withOrder(
+					gameCommandOptions[GameCommandOptionEnum.targetCharacter],
 					1
 				),
-				[GameCommandOptionEnum.gameRollType]: withOrder(
-					gameCommandOptions[GameCommandOptionEnum.gameRollType],
+				[GameCommandOptionEnum.rollType]: withOrder(
+					gameCommandOptions[GameCommandOptionEnum.rollType],
 					2
 				),
-				[GameCommandOptionEnum.gameDiceRollOrModifier]: withOrder(
-					gameCommandOptions[GameCommandOptionEnum.gameDiceRollOrModifier],
+				[GameCommandOptionEnum.diceRollOrModifier]: withOrder(
+					gameCommandOptions[GameCommandOptionEnum.diceRollOrModifier],
 					3
 				),
 				[GameCommandOptionEnum.initCharacterTarget]: withOrder(

--- a/packages/documentation/src/commands/game/game.command-options.ts
+++ b/packages/documentation/src/commands/game/game.command-options.ts
@@ -2,15 +2,14 @@ import { ApplicationCommandOptionType } from 'discord-api-types/v10';
 import type { CommandOptions, SpecificCommandOptions } from '../helpers/commands.types.js';
 
 export enum GameCommandOptionEnum {
-	gameGiveOption = 'game-give-option',
-	gameGiveAmount = 'game-give-amount',
-	gameSheetStyle = 'game-sheet-style',
-	gameCreateName = 'game-name',
-	gameTargetGame = 'game-target-game',
-	gameKickCharacter = 'character',
-	gameRollType = 'game-roll-type',
-	gameTargetCharacter = 'game-target-character',
-	gameDiceRollOrModifier = 'game-dice-roll-or-modifier',
+	giveOption = 'give-option',
+	giveAmount = 'give-amount',
+	sheetStyle = 'sheet-style',
+	createName = 'name',
+	targetGame = 'target-game',
+	targetCharacter = 'character',
+	rollType = 'roll-type',
+	diceRollOrModifier = 'dice-roll-or-modifier',
 	skillChoice = 'skill',
 	rollExpression = 'dice',
 	rollSecret = 'secret',
@@ -19,74 +18,67 @@ export enum GameCommandOptionEnum {
 }
 
 export const gameCommandOptions = {
-	[GameCommandOptionEnum.gameGiveOption]: {
-		name: GameCommandOptionEnum.gameGiveOption,
+	[GameCommandOptionEnum.giveOption]: {
+		name: GameCommandOptionEnum.giveOption,
 		description: 'The type of resource to give of (eg. hp, hero points, etc).',
 		required: true,
 		autocomplete: true,
 		type: ApplicationCommandOptionType.String,
 	},
-	[GameCommandOptionEnum.gameGiveAmount]: {
-		name: GameCommandOptionEnum.gameGiveAmount,
+	[GameCommandOptionEnum.giveAmount]: {
+		name: GameCommandOptionEnum.giveAmount,
 		description: 'The amount to give. Put "-" before to take the amount away',
 		required: true,
 		type: ApplicationCommandOptionType.String,
 	},
-	[GameCommandOptionEnum.gameSheetStyle]: {
-		name: GameCommandOptionEnum.gameSheetStyle,
+	[GameCommandOptionEnum.sheetStyle]: {
+		name: GameCommandOptionEnum.sheetStyle,
 		description: 'Whether to show only counters like hp, basic stats, or a full sheet.',
 		required: false,
 		type: ApplicationCommandOptionType.String,
 		choices: [
 			{
-				name: 'countersOnly',
-				value: 'countersOnly',
+				name: 'counters_only',
+				value: 'counters_only',
 			},
 			{
-				name: 'basicStats',
-				value: 'basicStats',
+				name: 'basic_stats',
+				value: 'basic_stats',
 			},
 			{
-				name: 'fullSheet',
-				value: 'fullSheet',
+				name: 'full_sheet',
+				value: 'full_sheet',
 			},
 		],
 	},
-	[GameCommandOptionEnum.gameCreateName]: {
-		name: GameCommandOptionEnum.gameCreateName,
+	[GameCommandOptionEnum.createName]: {
+		name: GameCommandOptionEnum.createName,
 		description: 'The name for the new game.',
 		required: true,
 		type: ApplicationCommandOptionType.String,
 	},
-	[GameCommandOptionEnum.gameTargetGame]: {
-		name: GameCommandOptionEnum.gameTargetGame,
+	[GameCommandOptionEnum.targetGame]: {
+		name: GameCommandOptionEnum.targetGame,
 		description: 'The game to target.',
 		required: true,
 		autocomplete: true,
 		type: ApplicationCommandOptionType.String,
 	},
-	[GameCommandOptionEnum.gameKickCharacter]: {
-		name: GameCommandOptionEnum.gameKickCharacter,
-		description: 'The character to kick from the game.',
-		required: true,
-		autocomplete: true,
-		type: ApplicationCommandOptionType.String,
-	},
-	[GameCommandOptionEnum.gameRollType]: {
-		name: GameCommandOptionEnum.gameRollType,
+	[GameCommandOptionEnum.rollType]: {
+		name: GameCommandOptionEnum.rollType,
 		description: 'The type of roll for the characters to make',
 		required: true,
 		type: ApplicationCommandOptionType.String,
 	},
-	[GameCommandOptionEnum.gameTargetCharacter]: {
-		name: GameCommandOptionEnum.gameTargetCharacter,
+	[GameCommandOptionEnum.targetCharacter]: {
+		name: GameCommandOptionEnum.targetCharacter,
 		description: 'Rolls for a single character instead of all characters.',
 		required: true,
 		autocomplete: true,
 		type: ApplicationCommandOptionType.String,
 	},
-	[GameCommandOptionEnum.gameDiceRollOrModifier]: {
-		name: GameCommandOptionEnum.gameDiceRollOrModifier,
+	[GameCommandOptionEnum.diceRollOrModifier]: {
+		name: GameCommandOptionEnum.diceRollOrModifier,
 		description: 'The dice roll if doing a custom roll, or a modifier to add to the roll.',
 		required: false,
 		type: ApplicationCommandOptionType.String,

--- a/packages/documentation/src/commands/game/game.documentation.ts
+++ b/packages/documentation/src/commands/game/game.documentation.ts
@@ -18,7 +18,7 @@ export const gameCommandDocumentation: CommandDocumentation<typeof gameCommandDe
 					type: CommandResponseTypeEnum.success,
 					message: 'Yip! I created the game "Season of Ghosts" in this server.',
 					options: {
-						[GameCommandOptionEnum.gameCreateName]: 'Season of Ghosts',
+						[GameCommandOptionEnum.createName]: 'Season of Ghosts',
 					},
 				},
 			],
@@ -33,7 +33,7 @@ export const gameCommandDocumentation: CommandDocumentation<typeof gameCommandDe
 					type: CommandResponseTypeEnum.success,
 					message: 'Yip! Lilac Sootsnout joined the game "Season of Ghosts"!',
 					options: {
-						[GameCommandOptionEnum.gameTargetGame]: 'Season of Ghosts',
+						[GameCommandOptionEnum.targetGame]: 'Season of Ghosts',
 					},
 				},
 			],
@@ -49,7 +49,7 @@ export const gameCommandDocumentation: CommandDocumentation<typeof gameCommandDe
 					message:
 						'Yip! I set the game "Season of Ghosts" as your active game in this server.',
 					options: {
-						[GameCommandOptionEnum.gameTargetGame]: 'Season of Ghosts',
+						[GameCommandOptionEnum.targetGame]: 'Season of Ghosts',
 					},
 				},
 			],
@@ -64,7 +64,7 @@ export const gameCommandDocumentation: CommandDocumentation<typeof gameCommandDe
 					type: CommandResponseTypeEnum.success,
 					message: 'Yip! Lilac Sootsnout left the game "Season of Ghosts"!',
 					options: {
-						[GameCommandOptionEnum.gameTargetGame]: 'Season of Ghosts',
+						[GameCommandOptionEnum.targetGame]: 'Season of Ghosts',
 					},
 				},
 			],
@@ -79,8 +79,8 @@ export const gameCommandDocumentation: CommandDocumentation<typeof gameCommandDe
 					type: CommandResponseTypeEnum.success,
 					message: 'Yip! I kicked Lilac Sootsnout out of the game "Season of Ghosts"!',
 					options: {
-						[GameCommandOptionEnum.gameTargetGame]: 'Season of Ghosts',
-						[GameCommandOptionEnum.gameKickCharacter]: 'Lilac Sootsnout',
+						[GameCommandOptionEnum.targetGame]: 'Season of Ghosts',
+						[GameCommandOptionEnum.targetCharacter]: 'Lilac Sootsnout',
 					},
 				},
 			],
@@ -95,7 +95,7 @@ export const gameCommandDocumentation: CommandDocumentation<typeof gameCommandDe
 					type: CommandResponseTypeEnum.success,
 					message: 'Yip! I deleted the game "Season of Ghosts" in this server.',
 					options: {
-						[GameCommandOptionEnum.gameTargetGame]: 'Season of Ghosts',
+						[GameCommandOptionEnum.targetGame]: 'Season of Ghosts',
 					},
 				},
 			],
@@ -110,7 +110,7 @@ export const gameCommandDocumentation: CommandDocumentation<typeof gameCommandDe
 					title: 'Success',
 					type: CommandResponseTypeEnum.success,
 					options: {
-						[GameCommandOptionEnum.gameTargetCharacter]: 'Lilac Sootsnout',
+						[GameCommandOptionEnum.targetCharacter]: 'Lilac Sootsnout',
 						[RollCommandOptionEnum.skillChoice]: 'Society',
 					},
 					embeds: [
@@ -138,7 +138,7 @@ export const gameCommandDocumentation: CommandDocumentation<typeof gameCommandDe
 				{
 					title: 'Success',
 					type: CommandResponseTypeEnum.success,
-					options: { [GameCommandOptionEnum.gameTargetCharacter]: 'All Players' },
+					options: { [GameCommandOptionEnum.targetCharacter]: 'All Players' },
 					message: 'Yip! All the characters in your game were already in the initiative!',
 				},
 			],
@@ -152,7 +152,7 @@ export const gameCommandDocumentation: CommandDocumentation<typeof gameCommandDe
 					title: 'Success',
 					type: CommandResponseTypeEnum.success,
 					options: {
-						[GameCommandOptionEnum.gameTargetCharacter]: 'All Players',
+						[GameCommandOptionEnum.targetCharacter]: 'All Players',
 					},
 					embeds: [
 						{
@@ -181,9 +181,9 @@ export const gameCommandDocumentation: CommandDocumentation<typeof gameCommandDe
 					title: 'Success',
 					type: CommandResponseTypeEnum.success,
 					options: {
-						[GameCommandOptionEnum.gameTargetCharacter]: 'Lilac Sootsnout',
-						[GameCommandOptionEnum.gameGiveOption]: 'hero points',
-						[GameCommandOptionEnum.gameGiveAmount]: '1',
+						[GameCommandOptionEnum.targetCharacter]: 'Lilac Sootsnout',
+						[GameCommandOptionEnum.giveOption]: 'hero points',
+						[GameCommandOptionEnum.giveAmount]: '1',
 					},
 					message: 'Yip! I gave 1 hero point(s) to Lilac Sootsnout! New total: 2/3',
 				},
@@ -198,8 +198,8 @@ export const gameCommandDocumentation: CommandDocumentation<typeof gameCommandDe
 					title: 'Success',
 					type: CommandResponseTypeEnum.success,
 					options: {
-						[GameCommandOptionEnum.gameTargetCharacter]: 'All Players',
-						[GameCommandOptionEnum.gameRollType]: 'reflex',
+						[GameCommandOptionEnum.targetCharacter]: 'All Players',
+						[GameCommandOptionEnum.rollType]: 'reflex',
 					},
 					embeds: [
 						{

--- a/packages/documentation/src/commands/gameplay/gameplay.command-definition.ts
+++ b/packages/documentation/src/commands/gameplay/gameplay.command-definition.ts
@@ -26,21 +26,19 @@ export const gameplayCommandDefinition = {
 				'Applies damage to a character, effecting tempHp, stamina (if enabled), and hp.',
 			type: ApplicationCommandOptionType.Subcommand,
 			options: {
-				[GameplayCommandOptionEnum.gameplayTargetCharacter]: withOrder(
+				[GameplayCommandOptionEnum.targetCharacter]: withOrder(
 					{
-						...gameplayCommandOptions[
-							GameplayCommandOptionEnum.gameplayTargetCharacter
-						],
+						...gameplayCommandOptions[GameplayCommandOptionEnum.targetCharacter],
 						required: true,
 					},
 					1
 				),
-				[GameplayCommandOptionEnum.gameplayDamageAmount]: withOrder(
-					gameplayCommandOptions[GameplayCommandOptionEnum.gameplayDamageAmount],
+				[GameplayCommandOptionEnum.damageAmount]: withOrder(
+					gameplayCommandOptions[GameplayCommandOptionEnum.damageAmount],
 					2
 				),
-				[GameplayCommandOptionEnum.gameplayDamageType]: withOrder(
-					gameplayCommandOptions[GameplayCommandOptionEnum.gameplayDamageType],
+				[GameplayCommandOptionEnum.damageType]: withOrder(
+					gameplayCommandOptions[GameplayCommandOptionEnum.damageType],
 					3
 				),
 			},
@@ -50,16 +48,16 @@ export const gameplayCommandDefinition = {
 			description: "Sets a character's gameplay stat (such as hp) to a value",
 			type: ApplicationCommandOptionType.Subcommand,
 			options: {
-				[GameplayCommandOptionEnum.gameplaySetOption]: withOrder(
-					gameplayCommandOptions[GameplayCommandOptionEnum.gameplaySetOption],
+				[GameplayCommandOptionEnum.setOption]: withOrder(
+					gameplayCommandOptions[GameplayCommandOptionEnum.setOption],
 					1
 				),
-				[GameplayCommandOptionEnum.gameplaySetValue]: withOrder(
-					gameplayCommandOptions[GameplayCommandOptionEnum.gameplaySetValue],
+				[GameplayCommandOptionEnum.setValue]: withOrder(
+					gameplayCommandOptions[GameplayCommandOptionEnum.setValue],
 					2
 				),
-				[GameplayCommandOptionEnum.gameplayTargetCharacter]: withOrder(
-					gameplayCommandOptions[GameplayCommandOptionEnum.gameplayTargetCharacter],
+				[GameplayCommandOptionEnum.targetCharacter]: withOrder(
+					gameplayCommandOptions[GameplayCommandOptionEnum.targetCharacter],
 					3
 				),
 			},
@@ -70,8 +68,8 @@ export const gameplayCommandDefinition = {
 				"Resets all of a character/npc's 'recoverable' stats (hp, stamina, resolve) to their maximum values.",
 			type: ApplicationCommandOptionType.Subcommand,
 			options: {
-				[GameplayCommandOptionEnum.gameplayTargetCharacter]: withOrder(
-					gameplayCommandOptions[GameplayCommandOptionEnum.gameplayTargetCharacter],
+				[GameplayCommandOptionEnum.targetCharacter]: withOrder(
+					gameplayCommandOptions[GameplayCommandOptionEnum.targetCharacter],
 					1
 				),
 			},
@@ -82,16 +80,16 @@ export const gameplayCommandDefinition = {
 				'Sets up a tracker to follow the changing statistics of one of your characters.',
 			type: ApplicationCommandOptionType.Subcommand,
 			options: {
-				[GameplayCommandOptionEnum.gameplayTargetCharacter]: withOrder(
-					gameplayCommandOptions[GameplayCommandOptionEnum.gameplayTargetCharacter],
+				[GameplayCommandOptionEnum.targetCharacter]: withOrder(
+					gameplayCommandOptions[GameplayCommandOptionEnum.targetCharacter],
 					1
 				),
-				[GameplayCommandOptionEnum.gameplayTargetChannel]: withOrder(
-					gameplayCommandOptions[GameplayCommandOptionEnum.gameplayTargetChannel],
+				[GameplayCommandOptionEnum.targetChannel]: withOrder(
+					gameplayCommandOptions[GameplayCommandOptionEnum.targetChannel],
 					2
 				),
-				[GameplayCommandOptionEnum.gameplayTrackerMode]: withOrder(
-					gameplayCommandOptions[GameplayCommandOptionEnum.gameplayTrackerMode],
+				[GameplayCommandOptionEnum.trackerMode]: withOrder(
+					gameplayCommandOptions[GameplayCommandOptionEnum.trackerMode],
 					3
 				),
 			},

--- a/packages/documentation/src/commands/gameplay/gameplay.command-options.ts
+++ b/packages/documentation/src/commands/gameplay/gameplay.command-options.ts
@@ -2,18 +2,18 @@ import { ApplicationCommandOptionType } from 'discord-api-types/v10';
 import type { CommandOptions, SpecificCommandOptions } from '../helpers/commands.types.js';
 
 export enum GameplayCommandOptionEnum {
-	gameplaySetOption = 'gameplay-set-option',
-	gameplayDamageAmount = 'gameplay-damage-amount',
-	gameplayDamageType = 'gameplay-damage-type',
-	gameplaySetValue = 'gameplay-set-value',
-	gameplayTargetCharacter = 'gameplay-target-character',
-	gameplayTargetChannel = 'gameplay-target-channel',
-	gameplayTrackerMode = 'gameplay-tracker-mode',
+	setOption = 'set-option',
+	damageAmount = 'damage-amount',
+	damageType = 'damage-type',
+	setValue = 'set-value',
+	targetCharacter = 'target-character',
+	targetChannel = 'target-channel',
+	trackerMode = 'tracker-mode',
 }
 
 export const gameplayCommandOptions = {
-	[GameplayCommandOptionEnum.gameplaySetOption]: {
-		name: GameplayCommandOptionEnum.gameplaySetOption,
+	[GameplayCommandOptionEnum.setOption]: {
+		name: GameplayCommandOptionEnum.setOption,
 		description: "What option to update on the target character's sheet",
 		required: true,
 		type: ApplicationCommandOptionType.String,
@@ -44,39 +44,39 @@ export const gameplayCommandOptions = {
 			},
 		],
 	},
-	[GameplayCommandOptionEnum.gameplayDamageAmount]: {
-		name: GameplayCommandOptionEnum.gameplayDamageAmount,
+	[GameplayCommandOptionEnum.damageAmount]: {
+		name: GameplayCommandOptionEnum.damageAmount,
 		description: 'The amount of damage to apply. A negative number heals the target.',
 		required: true,
 		type: ApplicationCommandOptionType.Number,
 	},
-	[GameplayCommandOptionEnum.gameplayDamageType]: {
-		name: GameplayCommandOptionEnum.gameplayDamageType,
+	[GameplayCommandOptionEnum.damageType]: {
+		name: GameplayCommandOptionEnum.damageType,
 		description: 'The type of damage to apply.',
 		required: false,
 		type: ApplicationCommandOptionType.String,
 	},
-	[GameplayCommandOptionEnum.gameplaySetValue]: {
-		name: GameplayCommandOptionEnum.gameplaySetValue,
+	[GameplayCommandOptionEnum.setValue]: {
+		name: GameplayCommandOptionEnum.setValue,
 		description: "The value to update to on the target character's sheet",
 		required: true,
 		type: ApplicationCommandOptionType.String,
 	},
-	[GameplayCommandOptionEnum.gameplayTargetCharacter]: {
-		name: GameplayCommandOptionEnum.gameplayTargetCharacter,
+	[GameplayCommandOptionEnum.targetCharacter]: {
+		name: GameplayCommandOptionEnum.targetCharacter,
 		description: 'What character to update. Defaults to your active character.',
 		required: true,
 		autocomplete: true,
 		type: ApplicationCommandOptionType.String,
 	},
-	[GameplayCommandOptionEnum.gameplayTargetChannel]: {
-		name: GameplayCommandOptionEnum.gameplayTargetChannel,
+	[GameplayCommandOptionEnum.targetChannel]: {
+		name: GameplayCommandOptionEnum.targetChannel,
 		description: 'What channel to send the tracker to. Defaults to your current channel.',
 		required: false,
 		type: ApplicationCommandOptionType.Channel,
 	},
-	[GameplayCommandOptionEnum.gameplayTrackerMode]: {
-		name: GameplayCommandOptionEnum.gameplayTrackerMode,
+	[GameplayCommandOptionEnum.trackerMode]: {
+		name: GameplayCommandOptionEnum.trackerMode,
 		description: 'How much information to track for the character.',
 		required: false,
 		type: ApplicationCommandOptionType.String,

--- a/packages/documentation/src/commands/gameplay/gameplay.documentation.ts
+++ b/packages/documentation/src/commands/gameplay/gameplay.documentation.ts
@@ -22,10 +22,9 @@ export const gameplayCommandDocumentation: CommandDocumentation<typeof gameplayC
 						type: CommandResponseTypeEnum.success,
 						message: 'Anatase Lightclaw took 5 damage!',
 						options: {
-							[GameplayCommandOptionEnum.gameplayTargetCharacter]:
-								'Anatase Lightclaw',
-							[GameplayCommandOptionEnum.gameplayDamageAmount]: 5,
-							[GameplayCommandOptionEnum.gameplayDamageType]: 'fire',
+							[GameplayCommandOptionEnum.targetCharacter]: 'Anatase Lightclaw',
+							[GameplayCommandOptionEnum.damageAmount]: 5,
+							[GameplayCommandOptionEnum.damageType]: 'fire',
 						},
 					},
 				],
@@ -40,10 +39,9 @@ export const gameplayCommandDocumentation: CommandDocumentation<typeof gameplayC
 						type: CommandResponseTypeEnum.success,
 						message: 'Stat set successfully.',
 						options: {
-							[GameplayCommandOptionEnum.gameplaySetOption]: 'hp',
-							[GameplayCommandOptionEnum.gameplaySetValue]: 22,
-							[GameplayCommandOptionEnum.gameplayTargetCharacter]:
-								'Anatase Lightclaw',
+							[GameplayCommandOptionEnum.setOption]: 'hp',
+							[GameplayCommandOptionEnum.setValue]: 22,
+							[GameplayCommandOptionEnum.targetCharacter]: 'Anatase Lightclaw',
 						},
 					},
 				],
@@ -59,8 +57,7 @@ export const gameplayCommandDocumentation: CommandDocumentation<typeof gameplayC
 						type: CommandResponseTypeEnum.success,
 						message: 'Yip! Anatase Lightclaw recovered! HP increased from 22 to 42',
 						options: {
-							[GameplayCommandOptionEnum.gameplayTargetCharacter]:
-								'Anatase Lightclaw',
+							[GameplayCommandOptionEnum.targetCharacter]: 'Anatase Lightclaw',
 						},
 					},
 				],
@@ -77,10 +74,9 @@ export const gameplayCommandDocumentation: CommandDocumentation<typeof gameplayC
 						message:
 							'Anatase Lightclaw Tracker\n\nLevel 3 Spellscale Kobold Monk\n\nHP: `42/42`\n\nHero Points: `1/3`,',
 						options: {
-							[GameplayCommandOptionEnum.gameplayTargetCharacter]:
-								'Anatase Lightclaw',
-							[GameplayCommandOptionEnum.gameplayTargetChannel]: '#trackers',
-							[GameplayCommandOptionEnum.gameplayTrackerMode]: 'full-sheet',
+							[GameplayCommandOptionEnum.targetCharacter]: 'Anatase Lightclaw',
+							[GameplayCommandOptionEnum.targetChannel]: '#trackers',
+							[GameplayCommandOptionEnum.trackerMode]: 'full-sheet',
 						},
 					},
 				],

--- a/packages/documentation/src/commands/init/init.command-definition.ts
+++ b/packages/documentation/src/commands/init/init.command-definition.ts
@@ -144,10 +144,8 @@ export const initCommandDefinition = {
 			type: ApplicationCommandOptionType.Subcommand,
 			options: {
 				[InitCommandOptionEnum.initCharacter]: withOrder(
-					{
-						...initCommandOptions[InitCommandOptionEnum.initCharacter],
-						required: false,
-					},
+					initCommandOptions[InitCommandOptionEnum.initCharacter],
+
 					1
 				),
 				[InitCommandOptionEnum.initNote]: withOrder(

--- a/packages/documentation/src/commands/init/init.command-options.ts
+++ b/packages/documentation/src/commands/init/init.command-options.ts
@@ -150,7 +150,7 @@ export const initCommandOptions = {
 	[InitCommandOptionEnum.skillChoice]: {
 		name: 'skill',
 		description: 'The skill to roll.',
-		required: true,
+		required: false,
 		autocomplete: true,
 		type: ApplicationCommandOptionType.String,
 	},


### PR DESCRIPTION
- Updated gameplay command options to use consistent naming conventions, changing 'gameplayTargetCharacter' to 'targetCharacter', 'gameplaySetOption' to 'setOption', and similar adjustments across various command definitions and options.
- Refactored related tests and documentation to reflect these changes, ensuring all references are updated accordingly.